### PR TITLE
Add user blacklist to settings file

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -38,6 +38,9 @@ class Application:
             A tuple of ``User`` objects
         """
 
+        # When implementing this function remember to drop names from the blacklist
+        # app_settings.blacklist
+
         raise NotImplementedError
 
     def _get_next_threshold(self, quota: AbstractQuota) -> int:

--- a/app/settings.py
+++ b/app/settings.py
@@ -20,6 +20,7 @@ class Settings(BaseSettings):
     ihome_quota_path: Path = Path('/ihome/crc/scripts/ihome_quota.json')
     thresholds: tuple[int, ...] = (75, 100)
     file_systems: Optional[tuple[FileSystem, ...]]
+    blacklist: Optional[set[str]]
 
 
 app_settings = Settings()


### PR DESCRIPTION
Users can be blacklisted by adding their username to the `blacklist` field in the settings file.