### PR TITLE
Add parsing from file to settings model

### DIFF
--- a/app/settings.py
+++ b/app/settings.py
@@ -10,7 +10,7 @@ from typing import Optional
 
 from pydantic import BaseSettings
 
-SETTINGS_PATH = Path('/etc/quota_notifier/config.json')
+SETTINGS_PATH = Path('/etc/notifier/config.json')
 DEFAULT_DB_PATH = Path(__file__).parent.resolve() / 'app_data.db'
 
 


### PR DESCRIPTION
The application defines default settings for everything except the file systems. I've added a bit of logic to parse the file systems from a settings file located at `/etc/notifier/config.json`.

@iamtroy412, @buttermutter let me know if you prefer a different location for the settings file.