### PR TITLE
Define email address domain in application settings

### DIFF
--- a/app/email.py
+++ b/app/email.py
@@ -37,7 +37,7 @@ class EmailTemplate:
             smtp: Optionally use a custom SMTP server
         """
 
-        domain = ApplicationSettings.get('email_domain')
+        domain = ApplicationSettings.get('email_domain').lstrip('@')
         return self.send(address=f'{user.username}@{domain}', smtp=smtp)
 
     def send(self, address: str, smtp: Optional[SMTP] = None) -> EmailMessage:

--- a/app/settings.py
+++ b/app/settings.py
@@ -93,7 +93,8 @@ class SettingsSchema(BaseSettings):
         title='User Email Address Domain',
         type=str,
         default='@pitt.edu',
-        description='String to append to usernames when generating user email addresses.')
+        description=('String to append to usernames when generating user email addresses. '
+                     'The leading `@` is optional.'))
 
     email_header: str = Field(
         title='Email Header Text',

--- a/tests/email/test_emailtemplate.py
+++ b/tests/email/test_emailtemplate.py
@@ -81,5 +81,6 @@ class SendingViaUsername(TestCase):
         user = User('myuser')
         sent_message = EmailTemplate([]).send_to_user(user, mock_smtp)
         username, domain = sent_message['To'].split('@')
+
         self.assertEqual(user.username, username)
-        self.assertEqual(domain, ApplicationSettings.get('email_domain'))
+        self.assertEqual('@' + domain, ApplicationSettings.get('email_domain'))


### PR DESCRIPTION
The `@pitt.edu` string that is used to create email addresses from usernames has been moved to the application settings module.