### PR TITLE
Update handling of extra definitions in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,16 +30,26 @@ def get_package_data(directory):
     return list(map(str, directory.rglob('*')))
 
 
-def get_extras(**paths):
+def get_extras(**extras_items):
     """Return a dictionary of package extras
 
-    Values for `tests` and `all` are generated automatically
+    Argument names are used to generate key values in the returned dictionary.
+    Argument values can be a list of packages or the path to a requirements
+    file. The `all` key is added to the returned dictionary automatically.
+
+    Args:
+        **extra sets of dependencies as a list of packages or requirements path
     """
 
-    extras = {'all': set(), 'tests': ['coverage'], }
-    for extra_name, path in paths.items():
-        extras[extra_name] = get_requirements(path)
+    extras = dict()
+    for extra_name, extra_definition in extras_items.items():
+        if isinstance(extra_definition, Path):
+            extras[extra_name] = get_requirements(extra_definition)
 
+        else:
+            extras[extra_name] = extra_definition
+
+    extras['all'] = set()
     for packages in extras.values():
         extras['all'].update(packages)
 
@@ -72,7 +82,7 @@ setup(
         notifier=app.cli:Application.execute
     """,
     install_requires=get_requirements(_pkg_requirements_path),
-    extras_require=get_extras(docs=_doc_requirements_path),
+    extras_require=get_extras(docs=_doc_requirements_path, tests=['coverage']),
     author=get_meta('author'),
     keywords='disk usage quota notify email',
     long_description=get_long_description(),


### PR DESCRIPTION
Testing requirements are no longer hardcoded in the `get_extras` function and can be configured as part of the `setup` function call.