### PR TITLE
Error on sphinx warnings

### DIFF
--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches: [ main ]
 
+env:
+  SPHINXOPTS: "-W"
+
 jobs:
   Build:
     name: Build Documentation
@@ -25,7 +28,7 @@ jobs:
         run: pip install .[docs]
 
       - name: Build and commit
-        uses: sphinx-notes/pages@master
+        uses: sphinx-notes/pages@v2
         with:
           documentation_path: docs/source
 

--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -5,35 +5,34 @@ on:
   push:
     branches: [ main ]
 
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
 jobs:
-  Build:
-    name: Build Documentation
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
     runs-on: ubuntu-latest
-    
     steps:
-      - name: Set up Python
-        uses: actions/setup-python@v1
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v2
+
+      - name: Build Docs
+        working-directory: docs
+        run: make html SPHINXOPTS="-W"
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
         with:
-          python-version: 3.9
+          path: docs/build/html
 
-      - name: Checkout source
-        uses: actions/checkout@master
-        with:
-          fetch-depth: 0 # Otherwise, you will fail to push refs to destination repo
-
-      - name: Install dependencies
-        run: pip install .[docs]
-
-      - name: Build and commit
-        uses: sphinx-notes/pages@v2
-        with:
-          documentation_path: docs/source
-        env:
-          SPHINXOPTS: "-W"
-
-      - name: Push changes
+      - name: Deploy to GitHub Pages
         if: github.event_name == 'push'
-        uses: ad-m/github-push-action@master
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          branch: gh-pages
+        uses: actions/deploy-pages@v1

--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -17,8 +17,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Setup Pages
-        uses: actions/configure-pages@v2
+      - name: Install dependencies
+        run: pip install .[docs]
 
       - name: Build Docs
         working-directory: docs
@@ -37,5 +37,8 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
 
     steps:
+      - name: Setup Pages
+        uses: actions/configure-pages@v2
+
       - name: Deploy to GitHub Pages
         uses: actions/deploy-pages@v1

--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -14,6 +14,11 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      - name: Set up Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.9
+
       - name: Checkout
         uses: actions/checkout@v3
 

--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -11,11 +11,7 @@ permissions:
   id-token: write
 
 jobs:
-  deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-
+  build:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -33,6 +29,13 @@ jobs:
         with:
           path: docs/build/html
 
+  deploy:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push'
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
       - name: Deploy to GitHub Pages
-        if: github.event_name == 'push'
         uses: actions/deploy-pages@v1

--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -5,9 +5,6 @@ on:
   push:
     branches: [ main ]
 
-env:
-  SPHINXOPTS: "-W"
-
 jobs:
   Build:
     name: Build Documentation
@@ -31,6 +28,8 @@ jobs:
         uses: sphinx-notes/pages@v2
         with:
           documentation_path: docs/source
+        env:
+          SPHINXOPTS: "-W"
 
       - name: Push changes
         if: github.event_name == 'push'

--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -35,8 +35,10 @@ jobs:
           path: docs/build/html
 
   deploy:
+    # if: github.event_name == 'push'
+    needs: [ build ]
+
     runs-on: ubuntu-latest
-    if: github.event_name == 'push'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -12,6 +12,7 @@ permissions:
 
 jobs:
   build:
+    name: Build Documentation
     runs-on: ubuntu-latest
     steps:
       - name: Set up Python
@@ -35,7 +36,8 @@ jobs:
           path: docs/build/html
 
   deploy:
-    # if: github.event_name == 'push'
+    name: Publish Documentation
+    if: github.event_name == 'push'
     needs: [ build ]
 
     runs-on: ubuntu-latest

--- a/docs/source/overview/install.rst
+++ b/docs/source/overview/install.rst
@@ -33,7 +33,7 @@ Configuration
 
 Application settings are configurable via JSON settings file.
 The example below includes a minimal subset of useful settings to get up and running.
-A full list of available settings is provided in the :doc:`confisg_options` page.
+A full list of available settings is provided in the :doc:`config_options` page.
 
 .. code-block:: json
 

--- a/docs/source/overview/install.rst
+++ b/docs/source/overview/install.rst
@@ -33,7 +33,7 @@ Configuration
 
 Application settings are configurable via JSON settings file.
 The example below includes a minimal subset of useful settings to get up and running.
-A full list of available settings is provided in the :doc:`config_options` page.
+A full list of available settings is provided in the :doc:`confisg_options` page.
 
 .. code-block:: json
 


### PR DESCRIPTION
Sphinx warnings can actually be fairly critical. This PR updates the CI to fail when a warning is raised. It also updates to the new "actions" method for publishing documentation to pages.