### PR TITLE
Adds set method to application settings

### DIFF
--- a/app/settings.py
+++ b/app/settings.py
@@ -219,6 +219,16 @@ class ApplicationSettings:
 
     @classmethod
     def set(cls, item: str, value: Any) -> None:
+        """Update a single value in the application settings
+
+        Args:
+            item: Name of the settings value to set
+            value: Value to set the settings item to
+
+        Raises:
+            ValueError: If the item name is not a valid setting
+        """
+
         if not hasattr(cls._parsed_settings, item):
             ValueError(f'Invalid settings option: {item}')
 
@@ -229,7 +239,7 @@ class ApplicationSettings:
         """Return a value from application settings
 
         Args:
-            item: The name of the settings value to retrieve
+            item: Name of the settings value to retrieve
         """
 
         return getattr(cls._parsed_settings, item)

--- a/app/settings.py
+++ b/app/settings.py
@@ -197,16 +197,6 @@ class ApplicationSettings:
     _parsed_settings: SettingsSchema = SettingsSchema()
 
     @classmethod
-    def configure_from_file(cls, path: Path) -> None:
-        """Update application settings using values from a given file path
-
-        Args:
-            path: Path to load settings from
-        """
-
-        cls._parsed_settings = SettingsSchema.parse_file(path)
-
-    @classmethod
     def configure(cls, **kwargs) -> None:
         """Reset settings to default values
 
@@ -215,7 +205,24 @@ class ApplicationSettings:
 
         cls._parsed_settings = SettingsSchema()
         for key, value in kwargs.items():
-            setattr(cls._parsed_settings, key, value)
+            cls.set(key, value)
+
+    @classmethod
+    def configure_from_file(cls, path: Path) -> None:
+        """Reset application settings using values from a given file path
+
+        Args:
+            path: Path to load settings from
+        """
+
+        cls._parsed_settings = SettingsSchema.parse_file(path)
+
+    @classmethod
+    def set(cls, item: str, value: Any) -> None:
+        if not hasattr(cls._parsed_settings, item):
+            ValueError(f'Invalid settings option: {item}')
+
+        setattr(cls._parsed_settings, item, value)
 
     @classmethod
     def get(cls, item: str) -> Any:

--- a/tests/settings/test_applicationsettings.py
+++ b/tests/settings/test_applicationsettings.py
@@ -18,3 +18,20 @@ class Configure(TestCase):
         # Test settings are restored
         ApplicationSettings.configure()
         self.assertFalse(ApplicationSettings.get('blacklist'))
+
+
+class Setter(TestCase):
+    """Test application settings can be manipulated via the setter method"""
+
+    def test_settings_is_updated(self) -> None:
+        """Test settings are updated by the setter"""
+
+        new_setting_value = 'test@some_domain.com'
+        ApplicationSettings.set('email_from', new_setting_value)
+        self.assertEqual(new_setting_value, ApplicationSettings.get('email_from'))
+
+    def test_error_invalid_settings(self) -> None:
+        """Test a ``ValueError`` is raised for an invalid settings name"""
+
+        with self.assertRaises(ValueError):
+            ApplicationSettings.set('fakesetting', 1)


### PR DESCRIPTION
Having only the `ApplicationSettings.configure` method for modifying settings makes it impossible to modify existing settings without resetting earlier changes. I've added a dedicated `set` method to allow modification of individual settings.