### PR TITLE
Uses enum type for distinguishing file system types

### DIFF
--- a/app/disk_utils.py
+++ b/app/disk_utils.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import json
 import math
 from abc import abstractmethod
+from enum import Enum
 from pathlib import Path
 from typing import Optional
 
@@ -173,16 +174,15 @@ class IhomeQuota(AbstractQuota):
 class QuotaFactory:
     """Factory object for dynamically creating quota instances of different types"""
 
-    quota_types = dict(
-        generic=GenericQuota,
-        beegfs=BeegfsQuota,
-        ihome=IhomeQuota
-    )
+    class QuotaType(Enum):
+        generic = GenericQuota
+        beegfs = BeegfsQuota
+        ihome = IhomeQuota
 
     def __new__(cls, quota_type: str, name: str, path: Path, user: User, **kwargs) -> AbstractQuota:
         """Create a new quota instance
 
-        See the ``quota_types`` attribute for valid values to the ``quota_type`` argument.
+        See the ``QuotaType`` attribute for valid values to the ``quota_type`` argument.
 
         Args:
             quota_type: String representation of the return type object
@@ -194,7 +194,10 @@ class QuotaFactory:
               A quota instance of the specified type created using the given arguments
         """
 
-        if quota_type not in cls.quota_types:
+        try:
+            quota_class = cls.QuotaType[quota_type].value
+
+        except KeyError:
             raise ValueError(f'Unknown quota type {quota_type}')
 
-        return cls.quota_types[quota_type].get_quota(name, path, user, **kwargs)
+        return quota_class.get_quota(name, path, user, **kwargs)

--- a/app/settings.py
+++ b/app/settings.py
@@ -47,7 +47,7 @@ class FileSystemSchema(BaseSettings):
 
         from .disk_utils import QuotaFactory
 
-        valid_types = list(QuotaFactory.quota_types.keys())
+        valid_types = list(QuotaFactory.QuotaType)
         if value not in valid_types:
             raise ValueError(f'File system types must be one of {valid_types}')
 

--- a/app/settings.py
+++ b/app/settings.py
@@ -47,9 +47,11 @@ class FileSystemSchema(BaseSettings):
 
         from .disk_utils import QuotaFactory
 
-        valid_types = list(QuotaFactory.QuotaType)
-        if value not in valid_types:
-            raise ValueError(f'File system types must be one of {valid_types}')
+        try:
+            QuotaFactory.QuotaType[value]
+
+        except KeyError as excep:
+            raise ValueError(f'File system types must be one of {list(QuotaFactory.QuotaType)}') from excep
 
         return value
 

--- a/tests/disk_utils/test_quotafactory.py
+++ b/tests/disk_utils/test_quotafactory.py
@@ -1,0 +1,22 @@
+"""Tests for the ``QuotaFactory`` class"""
+from pathlib import Path
+from unittest import TestCase
+
+from app.disk_utils import GenericQuota, QuotaFactory
+from app.shell import User
+
+
+class ReturnedQuotaType(TestCase):
+    """Test returned quotas match the expected type"""
+
+    def test_error_invalid_type(self) -> None:
+        """Test a ``ValueError`` is raised for invalid quota types"""
+
+        with self.assertRaises(ValueError):
+            QuotaFactory(quota_type='fake_type', name='test_quota', path=Path('/'), user=User('root'))
+
+    def test_type_matches_argument(self) -> None:
+        """Test the returned type matches the ``quota_type`` argument"""
+
+        quota = QuotaFactory(quota_type='generic', name='test_quota', path=Path('/'), user=User('root'))
+        self.assertIsInstance(quota, GenericQuota)

--- a/tests/settings/test_filesystemschema.py
+++ b/tests/settings/test_filesystemschema.py
@@ -36,8 +36,9 @@ class TypeValidation(TestCase):
     def test_valid_types_pass(self) -> None:
         """Test valid types do not raise errors"""
 
-        for fs_type in QuotaFactory.quota_types:
-            self.assertEqual(fs_type, FileSystemSchema.validate_type(fs_type))
+        for fs_type in QuotaFactory.QuotaType:
+            fs_type_string = fs_type.name
+            self.assertEqual(fs_type, FileSystemSchema.validate_type(fs_type_string))
 
     def test_invalid_type_error(self) -> None:
         """Test a ``ValueError`` is raised for invalid types"""

--- a/tests/settings/test_filesystemschema.py
+++ b/tests/settings/test_filesystemschema.py
@@ -38,7 +38,7 @@ class TypeValidation(TestCase):
 
         for fs_type in QuotaFactory.QuotaType:
             fs_type_string = fs_type.name
-            self.assertEqual(fs_type, FileSystemSchema.validate_type(fs_type_string))
+            self.assertEqual(fs_type_string, FileSystemSchema.validate_type(fs_type_string))
 
     def test_invalid_type_error(self) -> None:
         """Test a ``ValueError`` is raised for invalid types"""


### PR DESCRIPTION
File system types were being handline by a `Dict[string: AbstractQuota]` object. This has been replaced with an `Enum` subclass for clarity and easier use.