### PR TITLE
Adds support for Python 3.7 and 3.8

### DIFF
--- a/.github/workflows/Unittests.yml
+++ b/.github/workflows/Unittests.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.9", "3.10" ]
+        python-version: [ "3.7", "3.8", "3.9", "3.10" ]
 
     steps:
       - name: Checkout source

--- a/.github/workflows/Unittests.yml
+++ b/.github/workflows/Unittests.yml
@@ -25,6 +25,9 @@ jobs:
       - name: Install package dependencies
         run: pip install .[tests]
 
+      - name: Confirm executable was installed
+        run: notifier --version
+
       - name: Run tests with coverage
         run: |
           coverage run -m unittest discover 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=61.2", ]
+requires = ["setuptools>=59.0", ]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=59.0", ]
+requires = ["setuptools>=59.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -25,6 +25,9 @@ name = "Pitt Center for Research Computing"
 [project.readme]
 file = "README.md"
 content-type = "text/markdown"
+
+[project.scripts]
+notifier = "quota_notifier.cli:Application.execute"
 
 [project.optional-dependencies]
 docs = ["sphinx==5.2.1", "sphinx-argparse==0.3.1", "sphinx-copybutton==0.5.0", "sphinx-pydantic==0.1.1", "sphinx-rtd-theme==1.0.0", "sphinx-jsonschema==1.15", ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
     "Topic :: System :: Filesystems",
     "Topic :: System :: Monitoring"
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.7"
 dependencies = ["pydantic==1.10.2", "sqlalchemy==1.4.41", ]
 
 [[project.authors]]

--- a/quota_notifier/disk_utils.py
+++ b/quota_notifier/disk_utils.py
@@ -139,7 +139,8 @@ class BeegfsQuota(AbstractQuota):
             An instance of the parent class or None if the allocation does not exist
         """
 
-        if cached_quota := cls._cached_quotas.get(path, dict()).get(user.gid, None):
+        cached_quota = cls._cached_quotas.get(path, dict()).get(user.gid, None)
+        if cached_quota:
             quota = copy(cached_quota)
             quota.user = user
             return quota

--- a/quota_notifier/notify.py
+++ b/quota_notifier/notify.py
@@ -64,7 +64,8 @@ class UserNotifier:
             Notification.file_system == quota.name)
 
         last_notification = None
-        if db_entry := session.execute(query).scalars().first():
+        db_entry = session.execute(query).scalars().first()
+        if db_entry:
             last_notification = db_entry.threshold
 
         return last_notification

--- a/quota_notifier/settings.py
+++ b/quota_notifier/settings.py
@@ -6,7 +6,7 @@ Module Contents
 """
 
 from pathlib import Path
-from typing import Any
+from typing import Any, List, Set
 
 from pydantic import BaseSettings, Field, validator
 
@@ -82,21 +82,21 @@ class SettingsSchema(BaseSettings):
         default=Path('/ihome/crc/scripts/ihome_quota.json'),
         description='Path to ihome storage information.')
 
-    thresholds: list[int] = Field(
+    thresholds: List[int] = Field(
         title='Notification Thresholds',
-        type=list[int],
+        type=List[int],
         default=[98, 100],
         description='Usage percentages to issue notifications for.')
 
-    file_systems: list[FileSystemSchema] = Field(
+    file_systems: List[FileSystemSchema] = Field(
         title='Monitored File Systems',
-        type=list[FileSystemSchema],
+        type=List[FileSystemSchema],
         default=list(),
         description='List of additional settings that define which file systems to examine.')
 
-    blacklist: set[str] = Field(
+    blacklist: Set[str] = Field(
         title='Blacklisted Users',
-        type=set[str],
+        type=Set[str],
         default=set(),
         description='Do not notify usernames in this list.')
 
@@ -169,7 +169,7 @@ class SettingsSchema(BaseSettings):
         ))
 
     @validator('file_systems')
-    def validate_unique_file_systems(cls, value: list[FileSystemSchema]) -> list[FileSystemSchema]:
+    def validate_unique_file_systems(cls, value: List[FileSystemSchema]) -> List[FileSystemSchema]:
         """Ensure file systems have unique names/paths
 
         Args:


### PR DESCRIPTION
Changes to impliment support for older python versions.
- Rolls back the required `setuptools` version
- Refactors code to remove newer python features (typhinting from primitives and walrus operators) 
- Adds older python versions to CI