### PR TITLE
Bump setuptools requirement to 61.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=59.0"]
+requires = ["setuptools>=61.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -16,7 +16,7 @@ classifiers = [
     "Topic :: System :: Filesystems",
     "Topic :: System :: Monitoring"
 ]
-requires-python = ">=3.7"
+requires-python = ">=3.7z"
 dependencies = ["pydantic==1.10.2", "sqlalchemy==1.4.41", ]
 
 [[project.authors]]


### PR DESCRIPTION
Using older versions of setuptools with pipx results in the following error:

```No apps associated with package UNKNOWN or its dependencies```

After looking into the error, the problem appears to be caused by how setuptools internally bundles some of its dependencies. Upgrading the setuptools version fixes the problem.