### PR TITLE
Define filesystem types as literal in Pydantic model

### DIFF
--- a/.github/workflows/Unittests.yml
+++ b/.github/workflows/Unittests.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.7", "3.8", "3.9", "3.10" ]
+        python-version: [ "3.8", "3.9", "3.10" ]
 
     steps:
       - name: Checkout source

--- a/docs/source/overview/install.rst
+++ b/docs/source/overview/install.rst
@@ -9,7 +9,7 @@ System Utilities
 The ``df`` command line utility must be installed for the quota notifier to
 process *generic* file systems. The ``beegfs-ctl`` utility is also required to
 support BeeGFS file systems. see :doc:`file_systems` for more details on how
-the different file system types are expected to be configrued.
+the different file system types are expected to be configured.
 
 Installing the Package
 ----------------------
@@ -21,15 +21,23 @@ The ``notifier`` command line utility is installable via the `pip <https://pip.p
 
    pipx install git+https://github.com/pitt-crc/quota_notifier.git
 
-If you are working as a developer/contributor, installation options are provided for extra dependencies:
+Installing for Developers
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If your system is running `pip ≥ 21.3 <https://pip.pypa.io/en/stable/news/#v21-3>`_
+and `setuptools ≥ 64 <https://github.com/pypa/setuptools/blob/main/CHANGES.rst#v6400>`_,
+the package can be installed in
+`editable mode <https://pip.pypa.io/en/stable/topics/local-project-installs/#editable-installs>`_.
 
 .. code-block:: bash
 
-    pip install -e quota_notifier.[docs]
+    pip install -e quota_notifier
 
-.. note:: Developers may also appreciate the use of
-   `editable mode <https://pip.pypa.io/en/stable/topics/local-project-installs/#editable-installs>`_
-   in the above example.
+Installation options are also provided for extra dependencies:
+
+.. code-block:: bash
+
+    pip install -e quota_notifier[docs]
 
 To install a specific subset of extras, chose from the options below.
 All options will install the ``notifier`` utility plus core package dependencies.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=61.0"]
+requires = ["setuptools>=64.0"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/quota_notifier/disk_utils.py
+++ b/quota_notifier/disk_utils.py
@@ -254,6 +254,8 @@ class QuotaFactory:
     class QuotaType(Enum):
         """Map file system types to quota objects"""
 
+        # When modifying these options, also update the options accepted by the settings schema
+        # settings.FileSystemSchema.type
         generic = GenericQuota
         beegfs = BeeGFSQuota
         ihome = IhomeQuota

--- a/quota_notifier/disk_utils.py
+++ b/quota_notifier/disk_utils.py
@@ -252,6 +252,8 @@ class QuotaFactory:
     """Factory object for dynamically creating quota instances of different types"""
 
     class QuotaType(Enum):
+        """Map file system types to quota objects"""
+
         generic = GenericQuota
         beegfs = BeeGFSQuota
         ihome = IhomeQuota

--- a/quota_notifier/settings.py
+++ b/quota_notifier/settings.py
@@ -8,9 +8,9 @@ Module Contents
 import logging
 from pathlib import Path
 from typing import Any, List, Set
+from typing import Literal
 
 from pydantic import BaseSettings, Field, validator
-from typing import Literal
 
 DEFAULT_DB_PATH = Path(__file__).parent.resolve() / 'app_data.db'
 

--- a/quota_notifier/settings.py
+++ b/quota_notifier/settings.py
@@ -6,12 +6,22 @@ Module Contents
 """
 
 import logging
+from enum import Enum
 from pathlib import Path
-from typing import Any, List, Set, Literal
+from typing import Any, List, Set
 
 from pydantic import BaseSettings, Field, validator, BaseModel
 
 DEFAULT_DB_PATH = Path(__file__).parent.resolve() / 'app_data.db'
+
+
+class FileSystemTypes(str, Enum):
+    """Valid string representations for file system types"""
+
+    # These values must match key names in disk_utils.QuotaFactory.QuotaType
+    generic: str = 'generic'
+    ihome: str = 'ihome'
+    beegfs: str = 'beegfs'
 
 
 class FileSystemSchema(BaseModel):
@@ -29,10 +39,10 @@ class FileSystemSchema(BaseModel):
         type=Path,
         description='Absolute path to the mounted file system')
 
-    type: Literal['generic', 'ihome', 'beegfs'] = Field(
+    type: FileSystemTypes = Field(
         ...,
         title='System Type',
-        type=Literal['generic', 'ihome', 'beegfs'],
+        type=FileSystemTypes,
         description='Type of the file system')
 
     @validator('path')

--- a/quota_notifier/settings.py
+++ b/quota_notifier/settings.py
@@ -7,14 +7,14 @@ Module Contents
 
 import logging
 from pathlib import Path
-from typing import Any, List, Set
+from typing import Any, List, Set, Literal
 
-from pydantic import BaseSettings, Field, validator
+from pydantic import BaseSettings, Field, validator, BaseModel
 
 DEFAULT_DB_PATH = Path(__file__).parent.resolve() / 'app_data.db'
 
 
-class FileSystemSchema(BaseSettings):
+class FileSystemSchema(BaseModel):
     """Defines the schema settings related to an individual file system"""
 
     name: str = Field(
@@ -29,33 +29,11 @@ class FileSystemSchema(BaseSettings):
         type=Path,
         description='Absolute path to the mounted file system')
 
-    type: str = Field(
+    type: Literal['generic', 'ihome', 'beegfs'] = Field(
         ...,
         title='System Type',
-        type=str,
+        type=Literal['generic', 'ihome', 'beegfs'],
         description='Type of the file system')
-
-    @validator('type')
-    def validate_type(cls, value: str) -> str:
-        """Ensure the given system type is a valid quota object
-
-        Args:
-            value: The value to validate
-
-        Returns:
-            The validated file system type
-        """
-
-        # Moved here to avoid circular import
-        from .disk_utils import QuotaFactory
-
-        try:
-            QuotaFactory.QuotaType[value]
-
-        except KeyError as excep:
-            raise ValueError(f'File system types must be one of {list(QuotaFactory.QuotaType)}') from excep
-
-        return value
 
     @validator('path')
     def validate_path(cls, value: Path) -> Path:

--- a/tests/settings/test_filesystemschema.py
+++ b/tests/settings/test_filesystemschema.py
@@ -3,6 +3,8 @@
 from pathlib import Path
 from unittest import TestCase
 
+from pydantic import ValidationError
+
 from quota_notifier.disk_utils import QuotaFactory
 from quota_notifier.settings import FileSystemSchema
 
@@ -33,15 +35,16 @@ class PathValidation(TestCase):
 class TypeValidation(TestCase):
     """Test validation of the ``type`` filed"""
 
-    def test_valid_types_pass(self) -> None:
+    @staticmethod
+    def test_valid_types_pass() -> None:
         """Test valid types do not raise errors"""
 
         for fs_type in QuotaFactory.QuotaType:
             fs_type_string = fs_type.name
-            self.assertEqual(fs_type_string, FileSystemSchema.validate_type(fs_type_string))
+            FileSystemSchema(path='/', name='test', type=fs_type_string)
 
     def test_invalid_type_error(self) -> None:
         """Test a ``ValueError`` is raised for invalid types"""
 
-        with self.assertRaises(ValueError):
-            FileSystemSchema.validate_type('fake_type')
+        with self.assertRaises(ValidationError):
+            FileSystemSchema(path='/', name='test', type='fake_type')

--- a/tests/settings/test_filesystemschema.py
+++ b/tests/settings/test_filesystemschema.py
@@ -3,8 +3,6 @@
 from pathlib import Path
 from unittest import TestCase
 
-from pydantic import ValidationError
-
 from quota_notifier.disk_utils import QuotaFactory
 from quota_notifier.settings import FileSystemSchema
 
@@ -35,16 +33,15 @@ class PathValidation(TestCase):
 class TypeValidation(TestCase):
     """Test validation of the ``type`` filed"""
 
-    @staticmethod
-    def test_valid_types_pass() -> None:
+    def test_valid_types_pass(self) -> None:
         """Test valid types do not raise errors"""
 
         for fs_type in QuotaFactory.QuotaType:
             fs_type_string = fs_type.name
-            FileSystemSchema(path='/', name='test', type=fs_type_string)
+            self.assertEqual(fs_type_string, FileSystemSchema.validate_type(fs_type_string))
 
     def test_invalid_type_error(self) -> None:
         """Test a ``ValueError`` is raised for invalid types"""
 
-        with self.assertRaises(ValidationError):
-            FileSystemSchema(path='/', name='test', type='fake_type')
+        with self.assertRaises(ValueError):
+            FileSystemSchema.validate_type('fake_type')


### PR DESCRIPTION
Resolves #82 

Addressing this issue was deceptively tricky. I played around with a few different approaches, including:

#### Pulling file system types dynamically from the `QuotaType` Enum class

This is the best option on paper. The `QuotaType` class defines the official mapping of string names to Quota object types.  Ideally, valid settings values should be determined via the `QuotaType`  class.

Unfortunately, you very quickly run into a circular import, and refactoring to avoid the import gets messy. Even after refactoring, I encountered a problem where pydantic didn't work with the `QuotaType` Enum class. Apparently pydantic requires Enums to map strings to primitive types. `QuotaType` maps strings to custom objects.

#### Writing a second enum class

I tried writing a second enum class and including a comment to keep the new class up to date with the `QuotaType`  class. Unfortunately, the sphinx pydantic plugin didn't like that. It looks like enums aren't supported by the documentation tool yet.

#### Using a `Literal` type hint

This is effectively the same as the previous option, but uses a `typing.Literal`  type hint instead (pydantic can dynamically cast and validate arguments using type hints.) Unfortunatly, `typing.Literal` was not available until Python 3.8.


Ultimately I got this working by dropping Python 3.7 support and using `typing.Literal` . It seemed like the best option :man_shrugging: 
 