### PR TITLE
Updates default SMTP settings

### DIFF
--- a/docs/source/overview/config_options.rst
+++ b/docs/source/overview/config_options.rst
@@ -2,7 +2,12 @@ Config Options
 ==============
 
 The ``SettingsSchema`` defines the available options in the application settings file.
-Note the ``file_systems`` field is a nested field and should adhere to the ``FileSystemSchema`` schema.
+
+.. important:: The top level ``file_systems`` field is a nested field and entries
+   should adhere to the :ref:`#/definitions/FileSystemSchema` schema outlined below.
+
+.. note:: If the SMTP host is `''` and the STMP port is `0`, the OS default behavior
+   will be used for connecting to the SMTP server.
 
 .. pydantic:: quota_notifier.settings.SettingsSchema
 

--- a/docs/source/overview/config_options.rst
+++ b/docs/source/overview/config_options.rst
@@ -6,7 +6,7 @@ The ``SettingsSchema`` defines the available options in the application settings
 .. important:: The top level ``file_systems`` field is a nested field and entries
    should adhere to the :ref:`#/definitions/FileSystemSchema` schema outlined below.
 
-.. note:: If the SMTP host is `''` and the STMP port is `0`, the OS default behavior
+.. note:: If the SMTP host is ``''`` and the STMP port is ``0``, the OS default behavior
    will be used for connecting to the SMTP server.
 
 .. pydantic:: quota_notifier.settings.SettingsSchema

--- a/quota_notifier/settings.py
+++ b/quota_notifier/settings.py
@@ -110,11 +110,11 @@ class SettingsSchema(BaseSettings):
         default=30,
         description='Give up on checking a file system after the given number of seconds.')
 
-    # Settings for the smtp port
+    # Settings for the smtp host/port
     smtp_host: str = Field(
         title='SMTP Server Host Name',
         type=str,
-        default='localhost',
+        default='',
         description='Name of the remote SMTP host'
     )
 


### PR DESCRIPTION
Resolves #101 

Turns out the default SMTP port is 0 after all. Quoting the `smtplib.STMP` docs:

```
If the host is '' and port is 0, the OS default will be used.
```

I;ve updated the default settings to reflect the above.