### PR TITLE
Fix python version typo in pyproject.yaml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
     "Topic :: System :: Filesystems",
     "Topic :: System :: Monitoring"
 ]
-requires-python = ">=3.7z"
+requires-python = ">=3.7"
 dependencies = ["pydantic==1.10.2", "sqlalchemy==1.4.41", ]
 
 [[project.authors]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ keywords = ["disk", "usage", "quota", "notify", "email", ]
 classifiers = [
     "Environment :: Console",
     "Intended Audience :: System Administrators",
-    "Operating System :: POSIX :: IRIX",
+    "Operating System :: POSIX :: Linux",
     "Natural Language :: English",
     "Programming Language :: Python :: 3",
     "Topic :: System :: Filesystems",


### PR DESCRIPTION
The version `">=3.7"` was accidentally written as `">=3.7z"`.