### PR TITLE
Prevents package install in Python 3.7

### DIFF
--- a/.github/workflows/Unittests.yml
+++ b/.github/workflows/Unittests.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.8", "3.9", "3.10" ]
+        python-version: [ "3.7", "3.8", "3.9", "3.10" ]
 
     steps:
       - name: Checkout source

--- a/.github/workflows/Unittests.yml
+++ b/.github/workflows/Unittests.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.7", "3.8", "3.9", "3.10" ]
+        python-version: [ "3.8", "3.9", "3.10" ]
 
     steps:
       - name: Checkout source

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
     "Typing :: Typed"
 ]
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 dependencies = ["pydantic==1.10.2", "sqlalchemy==1.4.41", ]
 
 [[project.authors]]


### PR DESCRIPTION
The packaging file specified `requires-python = ">=3.7"`. This **should** have read `requires-python = ">=3.8"`.