### PR TITLE
Break documentation workflow into two workflows

### DIFF
--- a/.github/workflows/DocumentationBuild.yml
+++ b/.github/workflows/DocumentationBuild.yml
@@ -1,4 +1,4 @@
-name: Documentation
+name: Build Documentation
 
 on:
   pull_request:
@@ -7,8 +7,6 @@ on:
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 jobs:
   build:
@@ -34,20 +32,3 @@ jobs:
         uses: actions/upload-pages-artifact@v1
         with:
           path: docs/build/html
-
-  deploy:
-    name: Publish Documentation
-    if: github.event_name == 'push'
-    needs: [ build ]
-
-    runs-on: ubuntu-latest
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-
-    steps:
-      - name: Setup Pages
-        uses: actions/configure-pages@v2
-
-      - name: Deploy to GitHub Pages
-        uses: actions/deploy-pages@v1

--- a/.github/workflows/DocumentationPublish.yml
+++ b/.github/workflows/DocumentationPublish.yml
@@ -1,0 +1,31 @@
+name: Publish Documentation
+
+on:
+  release:
+    types: [ released ]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  build:
+    name: Build Documentation
+    uses: ./.github/workflows/DocumentationBuild.yml
+
+  deploy:
+    name: Publish Documentation
+    needs: [ build ]
+
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Setup Pages
+        uses: actions/configure-pages@v2
+
+      - name: Deploy to GitHub Pages
+        uses: actions/deploy-pages@v1


### PR DESCRIPTION
This is mostly an organizational edit. Moving the doc publishing logic means skipped publish jobs won't clutter up CI reporting in PRs.

I've also updated the workflow to publish docs on a release, not on updating `main`.