### PR TITLE
Updates CI triggers

### DIFF
--- a/.github/workflows/DocumentationBuild.yml
+++ b/.github/workflows/DocumentationBuild.yml
@@ -3,8 +3,6 @@ name: Build Documentation
 on:
   workflow_call:
   pull_request:
-  push:
-    branches: [ main ]
 
 permissions:
   contents: read

--- a/.github/workflows/DocumentationPublish.yml
+++ b/.github/workflows/DocumentationPublish.yml
@@ -1,7 +1,7 @@
 name: Publish Documentation
 
 on:
-  workflow_dispatch:
+  workflow_call:
   release:
     types: [ released ]
 

--- a/.github/workflows/Unittests.yml
+++ b/.github/workflows/Unittests.yml
@@ -2,7 +2,6 @@ name: Tests
 
 on:
   workflow_call:
-  workflow_dispatch:
   push:
 
 jobs:
@@ -37,6 +36,7 @@ jobs:
 
       # Report test coverage to codacy for the python version being tested
       - name: Report partial coverage results
+        if: github.event_name != 'workflow_dispatch'
         run: bash <(curl -Ls https://coverage.codacy.com/get.sh) report --partial -l Python -r report_${{ matrix.python-version }}.xml
         env:
           CODACY_PROJECT_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}


### PR DESCRIPTION
- Documentation test builds now only run on PRs
- Documentation build and publish workflows are both callable from other workflows
- Dispatch has been dropped from the test suite
- Intermediate Codacy reporting is skipped during workflow calls (Closes #113 )