### PR TITLE
Updates workflow action versions to address GH warnings

### DIFF
--- a/.github/workflows/DocumentationBuild.yml
+++ b/.github/workflows/DocumentationBuild.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: 3.9
 

--- a/.github/workflows/DocumentationPublish.yml
+++ b/.github/workflows/DocumentationPublish.yml
@@ -16,7 +16,7 @@ jobs:
     uses: ./.github/workflows/DocumentationBuild.yml
 
   deploy:
-    name: Publish Documentation
+    name: Deploy Documentation
     needs: [ build ]
 
     runs-on: ubuntu-latest
@@ -29,4 +29,5 @@ jobs:
         uses: actions/configure-pages@v2
 
       - name: Deploy to GitHub Pages
+        id: deployment
         uses: actions/deploy-pages@v1

--- a/.github/workflows/PublishPackage.yml
+++ b/.github/workflows/PublishPackage.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
           python-version: '3.x'
 

--- a/.github/workflows/Unittests.yml
+++ b/.github/workflows/Unittests.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 


### PR DESCRIPTION
Some of the CI actions are running older versions and are raising deprecation warnings. This PR updates the version numbers where necessary.