### PR TITLE
Fixes typo in workflow conditional

### DIFF
--- a/.github/workflows/Unittests.yml
+++ b/.github/workflows/Unittests.yml
@@ -36,14 +36,14 @@ jobs:
 
       # Report test coverage to codacy for the python version being tested
       - name: Report partial coverage results
-        if: github.event_name != 'workflow_dispatch'
+        if: github.event_name != 'workflow_call'
         run: bash <(curl -Ls https://coverage.codacy.com/get.sh) report --partial -l Python -r report_${{ matrix.python-version }}.xml
         env:
           CODACY_PROJECT_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}
 
   codacy-coverage-reporter:
     name: Report code coverage
-    if: github.event_name != 'workflow_dispatch'
+    if: github.event_name != 'workflow_call'
     runs-on: ubuntu-latest
     needs: python_tests
     steps:


### PR DESCRIPTION
I had accidentally put

`if: github.event_name != 'workflow_dispatch'`

instead of

`if: github.event_name != 'workflow_call'`

This PR fixes the typo.