### PR TITLE
Increase dependabot limit to 20

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,4 +3,7 @@ updates:
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "monthly"
+    open-pull-requests-limit: 20
+    ignore:
+      - dependency-name: "express"  # Newer versions of sphinx-jsonschema have compatibility issues


### PR DESCRIPTION
Increases PR limit for dependabot but only allows updates to happen once a month.