### PR TITLE
Drop permissions directive from publication workflow

### DIFF
--- a/.github/workflows/PublishPackage.yml
+++ b/.github/workflows/PublishPackage.yml
@@ -4,9 +4,6 @@ on:
   release:
     types: [ released ]
 
-permissions:
-  contents: read
-
 jobs:
   test:
     name: Run Tests

--- a/.github/workflows/Unittests.yml
+++ b/.github/workflows/Unittests.yml
@@ -36,14 +36,12 @@ jobs:
 
       # Report test coverage to codacy for the python version being tested
       - name: Report partial coverage results
-        if: github.event_name != 'workflow_call'
         run: bash <(curl -Ls https://coverage.codacy.com/get.sh) report --partial -l Python -r report_${{ matrix.python-version }}.xml
         env:
           CODACY_PROJECT_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}
 
   codacy-coverage-reporter:
     name: Report code coverage
-    if: github.event_name != 'workflow_call'
     runs-on: ubuntu-latest
     needs: python_tests
     steps:


### PR DESCRIPTION
The publication workflow is still getting tripped up by not being able to access the Codacy token. I'm dropping the permissions directive in the hopes that using the default actions permissions will address the problem.