### PR TITLE
Explicitly pass secret to reusable unittest workflow

### DIFF
--- a/.github/workflows/PublishPackage.yml
+++ b/.github/workflows/PublishPackage.yml
@@ -8,6 +8,8 @@ jobs:
   test:
     name: Run Tests
     uses: ./.github/workflows/Unittests.yml
+    secrets:
+      CODACY_PROJECT_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}
 
   build:
     name: Build Source Distribution


### PR DESCRIPTION
The publication workflow is failing because it can't report code coverage to codacy. Apparently workflow secrets (e.g., the codacy token), need to be passed explicitly to reused workflows ([docs](https://docs.github.com/en/actions/using-workflows/reusing-workflows#passing-inputs-and-secrets-to-a-reusable-workflow)).