### PR TITLE
Updates release step to use semantic release

### DIFF
--- a/.github/workflows/PublishPackage.yml
+++ b/.github/workflows/PublishPackage.yml
@@ -56,9 +56,10 @@ jobs:
           name: package-build
 
       - name: Publish package
-        uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          print_hash: true
+          verbose: true
           repository_url: ${{ secrets.REPO_URL }}
           user: ${{ secrets.REPO_USER }}
           password: ${{ secrets.REPO_PASSWORD }}
+          skip_existing: true


### PR DESCRIPTION
The pypa release action has updated its recommended usage to use releases instead of version hashes.