### PR TITLE
Specify host name in matrix configuration

### DIFF
--- a/.github/workflows/PublishPackage.yml
+++ b/.github/workflows/PublishPackage.yml
@@ -1,7 +1,6 @@
 name: Publish Package
 
 on:
-  push:
   release:
     types: [ released ]
 

--- a/.github/workflows/PublishPackage.yml
+++ b/.github/workflows/PublishPackage.yml
@@ -44,11 +44,14 @@ jobs:
     name: Publish Distribution
     needs: build
     runs-on: ubuntu-latest
+    environment: ${{ matrix.environment }}
 
     strategy:
       fail-fast: false
       matrix:
-        environment: [ publish-h2p ]
+        include:
+          - host: https://py00.crc.pitt.edu
+            environment: publish-h2p
 
     steps:
       - name: Download distribution from artifact storage

--- a/.github/workflows/PublishPackage.yml
+++ b/.github/workflows/PublishPackage.yml
@@ -58,6 +58,9 @@ jobs:
           path: dist
 
       - name: Publish package
-        run: |
-          pip install twine
-          twine upload --repository-url ${{ secrets.REPO_URL }} -u ${{ secrets.REPO_USER }} -p ${{ secrets.REPO_PASSWORD }} --verbose 
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          verbose: true
+          repository_url: ${{ secrets.REPO_URL }}
+          user: ${{ secrets.REPO_USER }}
+          password: ${{ secrets.REPO_PASSWORD }}

--- a/.github/workflows/PublishPackage.yml
+++ b/.github/workflows/PublishPackage.yml
@@ -64,7 +64,7 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           verbose: true
-          repository_url: ${{ secrets.REPO_URL }}
+          repository_url: ${{ matrix.host }}
           user: ${{ secrets.REPO_USER }}
           password: ${{ secrets.REPO_PASSWORD }}
           skip_existing: true

--- a/.github/workflows/PublishPackage.yml
+++ b/.github/workflows/PublishPackage.yml
@@ -64,4 +64,3 @@ jobs:
           repository_url: ${{ secrets.REPO_URL }}
           user: ${{ secrets.REPO_USER }}
           password: ${{ secrets.REPO_PASSWORD }}
-          skip_existing: true

--- a/.github/workflows/PublishPackage.yml
+++ b/.github/workflows/PublishPackage.yml
@@ -1,6 +1,7 @@
 name: Publish Package
 
 on:
+  push:
   release:
     types: [ released ]
 
@@ -54,6 +55,7 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: package-build
+          path: dist
 
       - name: Publish package
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/PublishPackage.yml
+++ b/.github/workflows/PublishPackage.yml
@@ -58,9 +58,6 @@ jobs:
           path: dist
 
       - name: Publish package
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          verbose: true
-          repository_url: ${{ secrets.REPO_URL }}
-          user: ${{ secrets.REPO_USER }}
-          password: ${{ secrets.REPO_PASSWORD }}
+        run: |
+          pip install twine
+          twine upload --repository-url ${{ secrets.REPO_URL }} -u ${{ secrets.REPO_USER }} -p ${{ secrets.REPO_PASSWORD }} --verbose 

--- a/.github/workflows/PublishPackage.yml
+++ b/.github/workflows/PublishPackage.yml
@@ -64,3 +64,4 @@ jobs:
           repository_url: ${{ secrets.REPO_URL }}
           user: ${{ secrets.REPO_USER }}
           password: ${{ secrets.REPO_PASSWORD }}
+          skip_existing: true


### PR DESCRIPTION
It is surprisingly easy to mess up an environmental configuration when building a GitHub actions workflow. When this happens, the requested environmental secret will be an empty string. This can have unintended consequences.

In the case of the `pypa/gh-action-pypi-publish` action, if the repository URL is blank, the action defaults to the official PyPi repo. By specifying the URL in the matrix and not the URL, this behavior becomes clearer and easier to debug.