### PR TITLE
Auto assigns package version on release using poetry

### DIFF
--- a/.github/workflows/PublishPackage.yml
+++ b/.github/workflows/PublishPackage.yml
@@ -24,13 +24,18 @@ jobs:
         with:
           python-version: '3.x'
 
-      - name: Install dependencies
+      - name: Install Poetry
+        run: pip install poetry
+
+      # Get the new package version from the release tag
+      # Release tags are expected to start with a "v", so the first character is stripped
+      - name: Set package version
         run: |
-          python -m pip install --upgrade pip
-          pip install build
+          tag=${{github.ref}}
+          poetry version "${tag:1}"
 
       - name: Build package
-        run: python -m build
+        run: poetry build -v
 
       - name: Upload distribution to artifact storage
         uses: actions/upload-artifact@v3
@@ -66,4 +71,3 @@ jobs:
           repository_url: ${{ matrix.host }}
           user: ${{ secrets.REPO_USER }}
           password: ${{ secrets.REPO_PASSWORD }}
-          skip_existing: true

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
-# Select files
-profile_app.py
-profile_settings.json
+# Pacakge manager files
+*.lock
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/docs/source/overview/install.rst
+++ b/docs/source/overview/install.rst
@@ -43,6 +43,8 @@ All options will install the ``notifier`` utility plus core package dependencies
 +----------------------+---------------------------------------------------------+
 | Install Option       | Description                                             |
 +======================+=========================================================+
+| ``[dev]``            | Includes all dependencies listed in this table.         |
++----------------------+---------------------------------------------------------+
 | ``[docs]``           | Dependencies required for building the documentation.   |
 +----------------------+---------------------------------------------------------+
 | ``[tests]``          | Dependencies required for running tests with coverage.  |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,14 +23,22 @@ classifiers = [
     "Typing :: Typed"
 ]
 
-[tool.poetry.dependencies]
-python = ">=3.8"
-pydantic = "==1.10.2"
-sqlalchemy = '==1.4.44'
-
 [tool.poetry.scripts]
 notifier = "quota_notifier.main:Application.execute"
 
-[tool.poetry.extras]
-docs = ["sphinx==5.3.0", "sphinx-argparse==0.4.0", "sphinx-copybutton==0.5.1", "sphinx-pydantic==0.1.1", "sphinx-rtd-theme==1.1.1", "sphinx-jsonschema==1.15", ]
-tests = ["coverage", ]
+[tool.poetry.dependencies]
+python = ">=3.8"
+pydantic = "==1.10.2"
+sqlalchemy = "==1.4.44"
+
+# Optional dependencies for running tests
+coverage = { version = "*", extras = ["dev", "tests"] }
+
+# Optional dependencies for building docs
+sphinx = { version = "5.3.0", extras = ["dev", "docs"] }
+sphinx-argparse = { version = "==0.4.0 ", extras = ["dev", "docs"] }
+sphinx-copybutton = { version = "==0.5.1 ", extras = ["dev", "docs"] }
+sphinx-pydantic = { version = "==0.1.1 ", extras = ["dev", "docs"] }
+sphinx-rtd-theme = { version = "==1.1.1 ", extras = ["dev", "docs"] }
+sphinx-jsonschema = { version = "==1.15", extras = ["dev", "docs"] }
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,16 @@
 [build-system]
-requires = ["setuptools>=64.0"]
-build-backend = "setuptools.build_meta"
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"
 
-[project]
+[tool.poetry]
 name = "quota-notifier"
-dynamic = ["version"]
+version = "0.3.1"
+authors = ["Pitt Center for Research Computing", ]
+readme = "README.md"
 description = "Automatic email notification tool for disk quota usage."
+homepage = "https://github.com/pitt-crc/quota_notifier"
+repository = "https://github.com/pitt-crc/quota_notifier"
+documentation = "https://crc-pages.pitt.edu/quota_notifier/"
 keywords = ["disk", "usage", "quota", "notify", "email", ]
 classifiers = [
     "Environment :: Console",
@@ -17,22 +22,28 @@ classifiers = [
     "Topic :: System :: Monitoring",
     "Typing :: Typed"
 ]
-requires-python = ">=3.8"
-dependencies = ["pydantic==1.10.2", "sqlalchemy==1.4.44", ]
 
-[[project.authors]]
-name = "Pitt Center for Research Computing"
+[tool.poetry.dependencies]
+python = ">=3.8"
+pydantic = "==1.10.2"
+sqlalchemy = '==1.4.44'
 
-[project.readme]
-file = "README.md"
-content-type = "text/markdown"
-
-[project.scripts]
+[tool.poetry.scripts]
 notifier = "quota_notifier.main:Application.execute"
 
-[project.optional-dependencies]
-docs = ["sphinx==5.3.0", "sphinx-argparse==0.4.0", "sphinx-copybutton==0.5.1", "sphinx-pydantic==0.1.1", "sphinx-rtd-theme==1.1.1", "sphinx-jsonschema==1.15", ]
-tests = ["coverage", ]
+[tool.poetry.group.docs]
+optional = true
 
-[tool.setuptools.dynamic]
-version = { attr = "quota_notifier.__version__" }
+[tool.poetry.group.docs.dependencies]
+sphinx = "==5.3.0"
+sphinx-argparse = "==0.4.0"
+sphinx-copybutton = "==0.5.1"
+sphinx-pydantic = "==0.1.1"
+sphinx-rtd-theme = "==1.1.1"
+sphinx-jsonschema = "==1.15"
+
+[tool.poetry.group.test]
+optional = true
+
+[tool.poetry.group.test.dependencies]
+coverage = "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,19 +31,6 @@ sqlalchemy = '==1.4.44'
 [tool.poetry.scripts]
 notifier = "quota_notifier.main:Application.execute"
 
-[tool.poetry.group.docs]
-optional = true
-
-[tool.poetry.group.docs.dependencies]
-sphinx = "==5.3.0"
-sphinx-argparse = "==0.4.0"
-sphinx-copybutton = "==0.5.1"
-sphinx-pydantic = "==0.1.1"
-sphinx-rtd-theme = "==1.1.1"
-sphinx-jsonschema = "==1.15"
-
-[tool.poetry.group.tests]
-optional = true
-
-[tool.poetry.group.tests.dependencies]
-coverage = "*"
+[tool.poetry.extras]
+docs = ["sphinx==5.3.0", "sphinx-argparse==0.4.0", "sphinx-copybutton==0.5.1", "sphinx-pydantic==0.1.1", "sphinx-rtd-theme==1.1.1", "sphinx-jsonschema==1.15", ]
+tests = ["coverage", ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,8 +42,8 @@ sphinx-pydantic = "==0.1.1"
 sphinx-rtd-theme = "==1.1.1"
 sphinx-jsonschema = "==1.15"
 
-[tool.poetry.group.test]
+[tool.poetry.group.tests]
 optional = true
 
-[tool.poetry.group.test.dependencies]
+[tool.poetry.group.tests.dependencies]
 coverage = "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "quota-notifier"
-version = "0.3.1"
+version = "0.0.0"  # Version is set dynamically by the CI tool on publication
 authors = ["Pitt Center for Research Computing", ]
 readme = "README.md"
 description = "Automatic email notification tool for disk quota usage."

--- a/quota_notifier/__init__.py
+++ b/quota_notifier/__init__.py
@@ -28,4 +28,6 @@ However, a user will receive additional notifications if their usage drops below
 a threshold before exceeding the threshold a second time.
 """
 
-__version__ = '0.2.2'
+import importlib.metadata
+
+__version__ = importlib.metadata.version(__package__)


### PR DESCRIPTION
Switches the package build system from Setuptools to Poetry. This allows two important improvements:

1. Package extras are now easier to manage in the toml file

Package extras are easier to define in Poetry, and a dependency can be assigned to multiple extras. In this case I've created the `dev` extra for installing the documentation and testing extras.

2. The package version is now set dynamically by the publication workflow

The package version in the repository has been set to `0.0.0`. From now on the package version is updated dynamically by the publication workflow using the release tag.