### PR TITLE
Drops extras from toml packaging specification

### DIFF
--- a/.github/workflows/Unittests.yml
+++ b/.github/workflows/Unittests.yml
@@ -24,7 +24,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install package dependencies
-        run: pip install .[tests]
+        run: pip install . coverage
 
       - name: Confirm executable was installed
         run: notifier --version

--- a/README.md
+++ b/README.md
@@ -5,6 +5,6 @@
 [![Tests](https://github.com/pitt-crc/quota_notifier/actions/workflows/Unittests.yml/badge.svg)](https://github.com/pitt-crc/quota_notifier/actions/workflows/Unittests.yml)
 [![Upload Python Package](https://github.com/pitt-crc/quota_notifier/actions/workflows/PublishPackage.yml/badge.svg)](https://github.com/pitt-crc/quota_notifier/actions/workflows/PublishPackage.yml)
 
-A simple command line utility for emailing users when they exceed disk usage thresholds 
+A simple command line utility for emailing users when they exceed disk usage thresholds.
 
 See the [official documentation](https://crc-pages.pitt.edu/quota_notifier/).

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -13,6 +13,7 @@ sys.path.insert(0, str(project_root))
 
 # -- Project information -----------------------------------------------------
 
+# noinspection PyPep8
 from quota_notifier import __version__
 
 project = 'Quota Notification Utility'

--- a/docs/source/overview/config_options.rst
+++ b/docs/source/overview/config_options.rst
@@ -6,7 +6,7 @@ The ``SettingsSchema`` defines the available options in the application settings
 .. important:: The top level ``file_systems`` field is a nested field and entries
    should adhere to the :ref:`#/definitions/FileSystemSchema` schema outlined below.
 
-.. note:: If the SMTP host is ``''`` and the STMP port is ``0``, the default OS behavior
+.. note:: If the SMTP host is ``''`` and the SMTP port is ``0``, the default OS behavior
    will be used for connecting to the SMTP server.
 
 .. pydantic:: quota_notifier.settings.SettingsSchema

--- a/docs/source/overview/install.rst
+++ b/docs/source/overview/install.rst
@@ -21,35 +21,6 @@ The ``notifier`` command line utility is installable via the `pip <https://pip.p
 
    pipx install git+https://github.com/pitt-crc/quota_notifier.git
 
-Installing for Developers
-^^^^^^^^^^^^^^^^^^^^^^^^^
-
-If is recommended for developers to install the package can be installed in
-`editable mode <https://pip.pypa.io/en/stable/topics/local-project-installs/#editable-installs>`_.
-
-.. code-block:: bash
-
-    pip install -e quota_notifier
-
-Installation options are also provided for extra dependencies:
-
-.. code-block:: bash
-
-    pip install -e quota_notifier[docs]
-
-To install a specific subset of extras, chose from the options below.
-All options will install the ``notifier`` utility plus core package dependencies.
-
-+----------------------+---------------------------------------------------------+
-| Install Option       | Description                                             |
-+======================+=========================================================+
-| ``[dev]``            | Includes all dependencies listed in this table.         |
-+----------------------+---------------------------------------------------------+
-| ``[docs]``           | Dependencies required for building the documentation.   |
-+----------------------+---------------------------------------------------------+
-| ``[tests]``          | Dependencies required for running tests with coverage.  |
-+----------------------+---------------------------------------------------------+
-
 Configuration
 -------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,9 +36,9 @@ coverage = { version = "*", extras = ["dev", "tests"] }
 
 # Optional dependencies for building docs
 sphinx = { version = "5.3.0", extras = ["dev", "docs"] }
-sphinx-argparse = { version = "==0.4.0 ", extras = ["dev", "docs"] }
-sphinx-copybutton = { version = "==0.5.1 ", extras = ["dev", "docs"] }
-sphinx-pydantic = { version = "==0.1.1 ", extras = ["dev", "docs"] }
-sphinx-rtd-theme = { version = "==1.1.1 ", extras = ["dev", "docs"] }
+sphinx-argparse = { version = "==0.4.0", extras = ["dev", "docs"] }
+sphinx-copybutton = { version = "==0.5.1", extras = ["dev", "docs"] }
+sphinx-pydantic = { version = "==0.1.1", extras = ["dev", "docs"] }
+sphinx-rtd-theme = { version = "==1.1.1", extras = ["dev", "docs"] }
 sphinx-jsonschema = { version = "==1.15", extras = ["dev", "docs"] }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,14 +31,11 @@ python = ">=3.8"
 pydantic = "==1.10.2"
 sqlalchemy = "==1.4.44"
 
-# Optional dependencies for running tests
-coverage = { version = "*", extras = ["dev", "tests"] }
-
-# Optional dependencies for building docs
-sphinx = { version = "5.3.0", extras = ["dev", "docs"] }
-sphinx-argparse = { version = "==0.4.0", extras = ["dev", "docs"] }
-sphinx-copybutton = { version = "==0.5.1", extras = ["dev", "docs"] }
-sphinx-pydantic = { version = "==0.1.1", extras = ["dev", "docs"] }
-sphinx-rtd-theme = { version = "==1.1.1", extras = ["dev", "docs"] }
-sphinx-jsonschema = { version = "==1.15", extras = ["dev", "docs"] }
+# Dependencies for building docs
+sphinx = "5.3.0"
+sphinx-argparse = "==0.4.0"
+sphinx-copybutton = "==0.5.1"
+sphinx-pydantic = "==0.1.1"
+sphinx-rtd-theme = "==1.1.1"
+sphinx-jsonschema = "==1.15"
 

--- a/quota_notifier/main.py
+++ b/quota_notifier/main.py
@@ -117,8 +117,7 @@ class Application:
         # Update application settings
         cls._configure_logging(args.verbose)
         cls._load_settings(args.settings, error_on_missing_file=args.validate)
-        if args.debug:
-            ApplicationSettings.set(debug=True)
+        ApplicationSettings.set(debug=args.debug)
 
         if args.validate:
             return


### PR DESCRIPTION
Try as I might, I can't get the Poetry groups/extras functionality to work with pip (i.e., using pep 508 compliant installs). I'm dropping the extras functionality.