### PR TITLE
Install documentation dependencies using poetry

### DIFF
--- a/.github/workflows/DocumentationBuild.yml
+++ b/.github/workflows/DocumentationBuild.yml
@@ -21,8 +21,8 @@ jobs:
         with:
           python-version: 3.9
 
-      - name: Install poetry
-        run: pip install poetry
+      - name: Install Poetry
+        uses: snok/install-poetry@v1
 
       - name: Install dependencies
         run: poetry install --with docs

--- a/.github/workflows/DocumentationBuild.yml
+++ b/.github/workflows/DocumentationBuild.yml
@@ -23,6 +23,8 @@ jobs:
 
       - name: Install Poetry
         uses: snok/install-poetry@v1
+        with:
+          virtualenvs-create: false
 
       - name: Install dependencies
         run: poetry install --with docs

--- a/.github/workflows/DocumentationBuild.yml
+++ b/.github/workflows/DocumentationBuild.yml
@@ -25,7 +25,7 @@ jobs:
         run: pip install poetry
 
       - name: Install dependencies
-        run: poetry install -E docs .
+        run: poetry install --with docs
 
       - name: Build Docs
         working-directory: docs

--- a/.github/workflows/DocumentationBuild.yml
+++ b/.github/workflows/DocumentationBuild.yml
@@ -13,16 +13,19 @@ jobs:
     name: Build Documentation
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout project source
+        uses: actions/checkout@v3
+
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
           python-version: 3.9
 
-      - name: Checkout
-        uses: actions/checkout@v3
+      - name: Install poetry
+        run: pip install poetry
 
       - name: Install dependencies
-        run: pip install .[docs]
+        run: poetry install -E docs .
 
       - name: Build Docs
         working-directory: docs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,14 +28,18 @@ notifier = "quota_notifier.main:Application.execute"
 
 [tool.poetry.dependencies]
 python = ">=3.8"
-pydantic = "==1.10.2"
-sqlalchemy = "==1.4.44"
+pydantic = "1.10.2"
+sqlalchemy = "1.4.44"
+
+[tool.poetry.group.docs]
+optional = true
 
 # Dependencies for building docs
+[tool.poetry.group.docs.dependencies]
 sphinx = "5.3.0"
-sphinx-argparse = "==0.4.0"
-sphinx-copybutton = "==0.5.1"
-sphinx-pydantic = "==0.1.1"
-sphinx-rtd-theme = "==1.1.1"
-sphinx-jsonschema = "==1.15"
+sphinx-argparse = "0.4.0"
+sphinx-copybutton = "0.5.1"
+sphinx-pydantic = "0.1.1"
+sphinx-rtd-theme = "1.1.1"
+sphinx-jsonschema = "1.15"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,6 @@ sqlalchemy = "1.4.44"
 [tool.poetry.group.docs]
 optional = true
 
-# Dependencies for building docs
 [tool.poetry.group.docs.dependencies]
 sphinx = "5.3.0"
 sphinx-argparse = "0.4.0"


### PR DESCRIPTION
Documentation dependencies are no longer required by default and can be installed using poetry