### PR TITLE
Modifies default DB path to be in CWD

### DIFF
--- a/quota_notifier/settings.py
+++ b/quota_notifier/settings.py
@@ -14,7 +14,7 @@ from pydantic import BaseSettings, Field, validator
 
 from quota_notifier.orm import DBConnection
 
-DEFAULT_DB_PATH = Path(__file__).parent.resolve() / 'app_data.db'
+DEFAULT_DB_PATH = Path.cwd().resolve() / 'app_data.db'
 
 
 class FileSystemSchema(BaseSettings):

--- a/tests/main/test_application.py
+++ b/tests/main/test_application.py
@@ -74,6 +74,12 @@ class LoggingConfiguration(TestCase):
         Application.execute(['-vvv'])
         self.assertEqual(logging.DEBUG, logging.getLogger().level)
 
+    def test_verbose_level_many(self):
+        """Test setting ``verbose`` to a very high number sets the logging level to ``DEBUG``"""
+
+        Application.execute(['-vvvvvvvvvv'])
+        self.assertEqual(logging.DEBUG, logging.getLogger().level)
+
 
 class DatabaseConfiguration(TestCase):
     """Test configuration of the application database"""

--- a/tests/main/test_application.py
+++ b/tests/main/test_application.py
@@ -74,12 +74,6 @@ class LoggingConfiguration(TestCase):
         Application.execute(['-vvv'])
         self.assertEqual(logging.DEBUG, logging.getLogger().level)
 
-    def test_verbose_level_many(self):
-        """Test setting ``verbose`` to a very high number sets the logging level to ``DEBUG``"""
-
-        Application.execute(['-vvvvvvvvvv'])
-        self.assertEqual(logging.DEBUG, logging.getLogger().level)
-
 
 class DatabaseConfiguration(TestCase):
     """Test configuration of the application database"""

--- a/tests/settings/test_settingsschema.py
+++ b/tests/settings/test_settingsschema.py
@@ -4,7 +4,6 @@ import tempfile
 from pathlib import Path
 from unittest import TestCase
 
-import quota_notifier
 from quota_notifier.settings import FileSystemSchema, SettingsSchema
 
 
@@ -16,13 +15,12 @@ class DefaultDBUrl(TestCase):
 
         self.assertTrue(SettingsSchema().db_url.startswith('sqlite:///'))
 
-    def test_in_app_dir(self) -> None:
-        """Test the default path is located inside the package directory"""
+    def test_defaults_to_cwd(self) -> None:
+        """Test the default path is located in the current working directory"""
 
-        app_path = Path(quota_notifier.__file__).resolve()
         db_path = Path(SettingsSchema().db_url.replace('sqlite:///', ''))
         self.assertTrue(db_path.is_absolute(), msg='Database path is not absolute')
-        self.assertEqual(app_path.parent, db_path.parent)
+        self.assertEqual(Path.cwd(), db_path.parent)
 
 
 class FileSystemValidation(TestCase):

--- a/tests/settings/test_settingsschema.py
+++ b/tests/settings/test_settingsschema.py
@@ -78,10 +78,9 @@ class DefaultDBUrl(TestCase):
 
         self.assertTrue(SettingsSchema().db_url.startswith('sqlite:///'))
 
-    def test_in_app_dir(self) -> None:
+    def test_in_cwd(self) -> None:
         """Test the default path is located in the current working directory"""
 
-        app_path = Path(quota_notifier.__file__).resolve()
         db_path = Path(SettingsSchema().db_url.replace('sqlite:///', ''))
         self.assertTrue(db_path.is_absolute(), msg='Database path is not absolute')
-        self.assertEqual(app_path.parent, db_path.parent)
+        self.assertEqual(Path.cwd(), db_path.parent)


### PR DESCRIPTION
Having the default DB location be in the install directory can result in the DB being deleted during upgrades. This approach is much safer and more explicit.