### PR TITLE
Blacklist uid/gid instead of user/group name

### DIFF
--- a/docs/source/overview/installation.rst
+++ b/docs/source/overview/installation.rst
@@ -32,8 +32,8 @@ A full list of available settings is provided in the :doc:`configuration` page.
 
    {
      "thresholds": [75, 100],
-     "blacklist": ["root"],
-     "group_blacklist": ["root"],
+     "blacklist": [0,],
+     "group_blacklist": [0,],
      "file_systems": [
          {
            "name": "main",

--- a/quota_notifier/notify.py
+++ b/quota_notifier/notify.py
@@ -95,13 +95,13 @@ class UserNotifier:
         logging.info('Fetching user list...')
 
         all_users = pwd.getpwall()
-        user_blacklist = ApplicationSettings.get('blacklist')
-        group_blacklist = ApplicationSettings.get('group_blacklist')
+        uid_blacklist = ApplicationSettings.get('blacklist')
+        gid_blacklist = ApplicationSettings.get('group_blacklist')
 
         allowed_users = []
         for user_entry in all_users:
             user = User(user_entry.pw_name)
-            if (user.username not in user_blacklist) and (user.group not in group_blacklist):
+            if (user.uid not in uid_blacklist) and (user.gid not in gid_blacklist):
                 allowed_users.append(user)
 
         logging.debug(f'Found {len(allowed_users)}/{len(all_users)} non-blacklisted users')

--- a/quota_notifier/settings.py
+++ b/quota_notifier/settings.py
@@ -103,16 +103,16 @@ class SettingsSchema(BaseSettings):
         default=list(),
         description='List of additional settings that define which file systems to examine.')
 
-    blacklist: Set[str] = Field(
+    blacklist: Set[int] = Field(
         title='Blacklisted Users',
-        type=Set[str],
-        default={'root', },
+        type=Set[int],
+        default={0, },
         description='Do not notify usernames in this list.')
 
-    group_blacklist: Set[str] = Field(
+    group_blacklist: Set[int] = Field(
         title='Blacklisted Groups',
-        type=Set[str],
-        default={'root', },
+        type=Set[int],
+        default={0, },
         description='Do not notify groups in this list.')
 
     disk_timeout: int = Field(

--- a/quota_notifier/settings.py
+++ b/quota_notifier/settings.py
@@ -104,16 +104,16 @@ class SettingsSchema(BaseSettings):
         description='List of additional settings that define which file systems to examine.')
 
     blacklist: Set[int] = Field(
-        title='Blacklisted Users',
+        title='Blacklisted User IDs',
         type=Set[int],
         default={0, },
-        description='Do not notify usernames in this list.')
+        description='Do not notify users with these ID values.')
 
     group_blacklist: Set[int] = Field(
-        title='Blacklisted Groups',
+        title='Blacklisted Group IDs',
         type=Set[int],
         default={0, },
-        description='Do not notify groups in this list.')
+        description='Do not notify groups with these ID values.')
 
     disk_timeout: int = Field(
         title='File System Timeout',

--- a/tests/notify/test_usernotifier.py
+++ b/tests/notify/test_usernotifier.py
@@ -39,7 +39,7 @@ class GetUsers(TestCase):
         all_users = [user.pw_name for user in pwd.getpwall()]
         self.assertIn('root', all_users)
 
-        ApplicationSettings.set(blacklist=['root'])
+        ApplicationSettings.set(blacklist=[0])
         returned_users = [user.username for user in UserNotifier().get_users()]
         self.assertNotIn('root', returned_users)
 

--- a/tests/settings/test_applicationsettings.py
+++ b/tests/settings/test_applicationsettings.py
@@ -22,12 +22,12 @@ class Defaults(TestCase):
     def test_blacklisted_users(self) -> None:
         """Test root is in blacklisted users"""
 
-        self.assertEqual({'root'}, ApplicationSettings.get('blacklist'))
+        self.assertEqual({0,}, ApplicationSettings.get('blacklist'))
 
     def test_blacklisted_groups(self) -> None:
         """Test root is in blacklisted groups"""
 
-        self.assertEqual({'root'}, ApplicationSettings.get('group_blacklist'))
+        self.assertEqual({0,}, ApplicationSettings.get('group_blacklist'))
 
 
 class ResetDefaults(TestCase):
@@ -38,7 +38,7 @@ class ResetDefaults(TestCase):
 
         ApplicationSettings.set(blacklist=['fake_username'])
         ApplicationSettings.reset_defaults()
-        self.assertEqual({'root'}, ApplicationSettings.get('blacklist'))
+        self.assertEqual({0,}, ApplicationSettings.get('blacklist'))
 
     def test_database_connection_is_reconfigured(self) -> None:
         """Test the database connection is reconfigured after resetting defaults"""
@@ -58,7 +58,7 @@ class ConfigureFromFile(TestCase):
     def test_setting_are_overwritten(self) -> None:
         """Test settings are overwritten with values from the file"""
 
-        settings = dict(blacklist=['fake_username'])
+        settings = dict(blacklist=[3, 4, 5])
 
         with NamedTemporaryFile() as temp_file:
             path_obj = Path(temp_file.name)
@@ -66,7 +66,7 @@ class ConfigureFromFile(TestCase):
                 json.dump(settings, io)
 
             ApplicationSettings.set_from_file(path_obj)
-            self.assertEqual({'fake_username'}, ApplicationSettings.get('blacklist'))
+            self.assertEqual({3, 4, 5}, ApplicationSettings.get('blacklist'))
 
     def test_invalid_file(self) -> None:
         """Test a ``ValidationError`` is raised for an invalid settings file"""


### PR DESCRIPTION
This PR updates the settings configuration to user user/group ids instead of names. It lays the ground work for support a range of ID values.