### PR TITLE
Renames group_blacklist setting to gid_blacklist

### DIFF
--- a/docs/source/overview/installation.rst
+++ b/docs/source/overview/installation.rst
@@ -33,7 +33,7 @@ A full list of available settings is provided in the :doc:`configuration` page.
    {
      "thresholds": [75, 100],
      "blacklist": [0,],
-     "group_blacklist": [0,],
+     "gid_blacklist": [0,],
      "file_systems": [
          {
            "name": "main",

--- a/quota_notifier/notify.py
+++ b/quota_notifier/notify.py
@@ -96,7 +96,7 @@ class UserNotifier:
 
         all_users = pwd.getpwall()
         uid_blacklist = ApplicationSettings.get('blacklist')
-        gid_blacklist = ApplicationSettings.get('group_blacklist')
+        gid_blacklist = ApplicationSettings.get('gid_blacklist')
 
         allowed_users = []
         for user_entry in all_users:

--- a/quota_notifier/settings.py
+++ b/quota_notifier/settings.py
@@ -109,7 +109,7 @@ class SettingsSchema(BaseSettings):
         default={0, },
         description='Do not notify users with these ID values.')
 
-    group_blacklist: Set[int] = Field(
+    gid_blacklist: Set[int] = Field(
         title='Blacklisted Group IDs',
         type=Set[int],
         default={0, },

--- a/tests/notify/test_usernotifier.py
+++ b/tests/notify/test_usernotifier.py
@@ -26,7 +26,7 @@ class GetUsers(TestCase):
     def test_includes_all_users(self) -> None:
         """Test all users except root are returned by default"""
 
-        ApplicationSettings.set(blacklist=[], group_blacklist=[])
+        ApplicationSettings.set(blacklist=[], gid_blacklist=[])
 
         returned_users = [user.username for user in UserNotifier().get_users()]
         all_users = [user.pw_name for user in pwd.getpwall()]

--- a/tests/settings/test_applicationsettings.py
+++ b/tests/settings/test_applicationsettings.py
@@ -27,7 +27,7 @@ class Defaults(TestCase):
     def test_blacklisted_groups(self) -> None:
         """Test root is in blacklisted groups"""
 
-        self.assertEqual({0,}, ApplicationSettings.get('group_blacklist'))
+        self.assertEqual({0,}, ApplicationSettings.get('gid_blacklist'))
 
 
 class ResetDefaults(TestCase):


### PR DESCRIPTION
Renames `group_blacklist` option in the settings file for clarity.