### PR TITLE
Support id ranges for uid/gid blacklists

### DIFF
--- a/docs/source/getting_started/usage.rst
+++ b/docs/source/getting_started/usage.rst
@@ -18,6 +18,17 @@ In the application settings file (located at ``/etc/notifier/settings.json`` by 
      "gid_blacklist": [0, 1, 5],
    }
 
+The ``uid_blacklist`` and ``gid_blacklist`` fields also accept ID ranges.
+For example, to ignore the ``root`` user in addition to users ``100`` through ``199``:
+
+.. code-block:: json
+
+   {
+     "uid_blacklist": [0, [100, 199]]
+   }
+
+All ID ranges are treated as being inclusive.
+
 .. note:: The default value for the ``uid_blacklist`` and ``gid_blacklist`` options is ``[0]`` which excludes
           the ``root`` user/group.
 

--- a/quota_notifier/notify.py
+++ b/quota_notifier/notify.py
@@ -88,7 +88,7 @@ class UserNotifier:
         """Return a collection of users to check quotas for
 
         Returns:
-            A iterable collection of ``User`` objects
+            An iterable collection of ``User`` objects
         """
 
         logging.info('Fetching user list...')

--- a/quota_notifier/notify.py
+++ b/quota_notifier/notify.py
@@ -6,11 +6,10 @@ Module Contents
 """
 
 import logging
-import pwd
 from bisect import bisect_right
 from email.message import EmailMessage
 from smtplib import SMTP
-from typing import Collection, Optional
+from typing import Collection, Optional, Set, Union, Tuple
 from typing import Iterable
 
 from sqlalchemy import delete, insert, select
@@ -84,8 +83,8 @@ class EmailTemplate:
 class UserNotifier:
     """Issue and manage user quota notifications"""
 
-    @staticmethod
-    def get_users() -> Iterable[User]:
+    @classmethod
+    def get_users(cls) -> Iterable[User]:
         """Return a collection of users to check quotas for
 
         Returns:
@@ -93,19 +92,37 @@ class UserNotifier:
         """
 
         logging.info('Fetching user list...')
-
-        all_users = pwd.getpwall()
         uid_blacklist = ApplicationSettings.get('uid_blacklist')
         gid_blacklist = ApplicationSettings.get('gid_blacklist')
 
         allowed_users = []
-        for user_entry in all_users:
-            user = User(user_entry.pw_name)
-            if (user.uid not in uid_blacklist) and (user.gid not in gid_blacklist):
+        for user in User.iter_all_users():
+            if not (cls._id_in_blacklist(user.uid, uid_blacklist) or cls._id_in_blacklist(user.gid, gid_blacklist)):
                 allowed_users.append(user)
 
-        logging.debug(f'Found {len(allowed_users)}/{len(all_users)} non-blacklisted users')
+        logging.debug(f'Found {len(allowed_users)} non-blacklisted users')
         return allowed_users
+
+    @staticmethod
+    def _id_in_blacklist(id_value: int, blacklist: Set[Union[int, Tuple[int, int]]]) -> bool:
+        """Return whether an ID is in a black list of ID values
+
+        Args:
+            id_value: The ID value to check
+            blacklist: A collection of ID values and ID ranges
+
+        Returns:
+            Whether the ID is in the blacklist
+        """
+
+        for id_def in blacklist:
+            if isinstance(id_def, int) and id_value == id_def:
+                return True
+
+            elif isinstance(id_def, tuple) and (id_def[0] <= id_value <= id_def[1]):
+                return True
+
+        return False
 
     @staticmethod
     def get_user_quotas(user: User) -> Iterable[AbstractQuota]:

--- a/quota_notifier/settings.py
+++ b/quota_notifier/settings.py
@@ -7,7 +7,7 @@ Module Contents
 
 import logging
 from pathlib import Path
-from typing import Any, List, Set
+from typing import Any, List, Union, Tuple, Set
 from typing import Literal
 
 from pydantic import BaseSettings, Field, validator
@@ -103,16 +103,16 @@ class SettingsSchema(BaseSettings):
         default=list(),
         description='List of additional settings that define which file systems to examine.')
 
-    uid_blacklist: Set[int] = Field(
+    uid_blacklist: Set[Union[int, Tuple[int, int]]] = Field(
         title='Blacklisted User IDs',
-        type=Set[int],
-        default={0, },
+        type=Set[Union[int, Tuple[int, int]]],
+        default=[0],
         description='Do not notify users with these ID values.')
 
-    gid_blacklist: Set[int] = Field(
+    gid_blacklist: Set[Union[int, Tuple[int, int]]] = Field(
         title='Blacklisted Group IDs',
-        type=Set[int],
-        default={0, },
+        type=Set[Union[int, Tuple[int, int]]],
+        default=[0],
         description='Do not notify groups with these ID values.')
 
     disk_timeout: int = Field(

--- a/quota_notifier/shell.py
+++ b/quota_notifier/shell.py
@@ -4,12 +4,14 @@ Module Contents
 ---------------
 """
 
+from __future__ import annotations
+
 import grp
 import logging
 import pwd
 from shlex import split
 from subprocess import PIPE, Popen
-from typing import Optional
+from typing import Optional, Iterator
 
 from quota_notifier.settings import ApplicationSettings
 
@@ -59,6 +61,13 @@ class User:
         """
 
         self._username = username
+
+    @classmethod
+    def iter_all_users(cls) -> Iterator[User]:
+        """Iterable over user objects for all users on the system"""
+
+        for user_entry in pwd.getpwall():
+            yield cls(user_entry.pw_name)
 
     @property
     def username(self) -> str:

--- a/tests/notify/test_usernotifier.py
+++ b/tests/notify/test_usernotifier.py
@@ -32,16 +32,33 @@ class GetUsers(TestCase):
         all_users = [user.pw_name for user in pwd.getpwall()]
         self.assertListEqual(all_users, returned_users)
 
-    def test_blacklisted_users_excluded(self) -> None:
-        """Test blacklisted users are not included in returned values"""
+    def test_blacklisted_by_uid(self) -> None:
+        """Test blacklisted UIDs are not included in returned values"""
 
-        # Make sure the premise for this test is satisfied
-        all_users = [user.pw_name for user in pwd.getpwall()]
-        self.assertIn('root', all_users)
+        ApplicationSettings.set(uid_blacklist={0}, gid_blacklist=set())
+        returned_uids = [user.uid for user in UserNotifier().get_users()]
+        self.assertNotIn(0, returned_uids)
 
-        ApplicationSettings.set(uid_blacklist=[0])
-        returned_users = [user.username for user in UserNotifier().get_users()]
-        self.assertNotIn('root', returned_users)
+    def test_blacklisted_by_gid(self) -> None:
+        """Test blacklisted GIDs are not included in returned values"""
+
+        ApplicationSettings.set(uid_blacklist=set(), gid_blacklist={0})
+        returned_gids = [user.gid for user in UserNotifier().get_users()]
+        self.assertNotIn(0, returned_gids)
+
+    def test_blacklisted_by_uid_range(self) -> None:
+        """Test blacklisted UID ranges are not included in returned values"""
+
+        ApplicationSettings.set(uid_blacklist={(0, 100)}, gid_blacklist=set())
+        returned_uids = [user.uid for user in UserNotifier().get_users()]
+        self.assertNotIn(0, returned_uids)
+
+    def test_blacklisted_by_gid_range(self) -> None:
+        """Test blacklisted GID ranges are not included in returned values"""
+
+        ApplicationSettings.set(uid_blacklist=set(), gid_blacklist={(0, 100)})
+        returned_gids = [user.gid for user in UserNotifier().get_users()]
+        self.assertNotIn(0, returned_gids)
 
 
 class GetUserQuotas(TestCase):

--- a/tests/settings/test_applicationsettings.py
+++ b/tests/settings/test_applicationsettings.py
@@ -22,12 +22,12 @@ class Defaults(TestCase):
     def test_blacklisted_users(self) -> None:
         """Test root is in blacklisted users"""
 
-        self.assertEqual({0,}, ApplicationSettings.get('uid_blacklist'))
+        self.assertEqual({0, }, ApplicationSettings.get('uid_blacklist'))
 
     def test_blacklisted_groups(self) -> None:
         """Test root is in blacklisted groups"""
 
-        self.assertEqual({0,}, ApplicationSettings.get('gid_blacklist'))
+        self.assertEqual({0, }, ApplicationSettings.get('gid_blacklist'))
 
 
 class ResetDefaults(TestCase):
@@ -38,7 +38,7 @@ class ResetDefaults(TestCase):
 
         ApplicationSettings.set(uid_blacklist=['fake_username'])
         ApplicationSettings.reset_defaults()
-        self.assertEqual({0,}, ApplicationSettings.get('uid_blacklist'))
+        self.assertEqual({0, }, ApplicationSettings.get('uid_blacklist'))
 
     def test_database_connection_is_reconfigured(self) -> None:
         """Test the database connection is reconfigured after resetting defaults"""
@@ -58,7 +58,7 @@ class ConfigureFromFile(TestCase):
     def test_setting_are_overwritten(self) -> None:
         """Test settings are overwritten with values from the file"""
 
-        settings = dict(uid_blacklist=[3, 4, 5])
+        settings = dict(uid_blacklist=[3, 4, [5, 100]])
 
         with NamedTemporaryFile() as temp_file:
             path_obj = Path(temp_file.name)
@@ -66,7 +66,7 @@ class ConfigureFromFile(TestCase):
                 json.dump(settings, io)
 
             ApplicationSettings.set_from_file(path_obj)
-            self.assertEqual({3, 4, 5}, ApplicationSettings.get('uid_blacklist'))
+            self.assertEqual({3, 4, (5, 100)}, ApplicationSettings.get('uid_blacklist'))
 
     def test_invalid_file(self) -> None:
         """Test a ``ValidationError`` is raised for an invalid settings file"""

--- a/tests/settings/test_settingsschema.py
+++ b/tests/settings/test_settingsschema.py
@@ -38,6 +38,28 @@ class VerbosityValidation(TestCase):
                 SettingsSchema(verbosity=value)
 
 
+class BlacklistValidation(TestCase):
+    """Test validation for the ``uid_blacklist`` and ``gid_blacklist`` fields"""
+
+    def test_error_on_id_range_len_1(self) -> None:
+        """Test a ``ValueError`` is raised for UID and GID ranges with 1 element"""
+
+        with self.assertRaisesRegex(ValueError, 'actual_length=1; expected_length=2'):
+            SettingsSchema(uid_blacklist=[[1], ])
+
+        with self.assertRaisesRegex(ValueError, 'actual_length=1; expected_length=2'):
+            SettingsSchema(gid_blacklist=[[1], ])
+
+    def test_error_on_id_range_len_3(self) -> None:
+        """Test a ``ValueError`` is raised for UID and GID ranges with 3 elements"""
+
+        with self.assertRaisesRegex(ValueError, 'actual_length=3; expected_length=2'):
+            SettingsSchema(uid_blacklist=[[1, 2, 3], ])
+
+        with self.assertRaisesRegex(ValueError, 'actual_length=3; expected_length=2'):
+            SettingsSchema(gid_blacklist=[[1, 2, 3], ])
+
+
 class FileSystemValidation(TestCase):
     """Test validation for the ``file_systems`` field"""
 

--- a/tests/shell/test_user.py
+++ b/tests/shell/test_user.py
@@ -1,5 +1,5 @@
 """Tests for the ``User`` class"""
-
+import pwd
 from unittest import TestCase
 
 from quota_notifier.shell import User
@@ -16,6 +16,23 @@ class UserInfo(TestCase):
         self.assertEqual(user.uid, 0)
         self.assertEqual(user.group, 'root')
         self.assertEqual(user.gid, 0)
+
+
+class IterAllUsers(TestCase):
+    """Test the ``iter_all_users`` method"""
+
+    def test_all_users_returned(self) -> None:
+        """Test the iterator returns all users on the system"""
+
+        all_usernames = {user_entry.pw_name for user_entry in pwd.getpwall()}
+        returned_users = [user.username for user in User.iter_all_users()]
+        self.assertCountEqual(all_usernames, returned_users)
+
+    def test_returned_as_user_objects(self) -> None:
+        """Test users are returned as ``User`` objects"""
+
+        for user in User.iter_all_users():
+            self.assertIsInstance(user, User)
 
 
 class StringRepresentation(TestCase):


### PR DESCRIPTION
ID values can now be defined using includive numerical ranges. For example, setting:

```json
{
  "uid_blacklist": [
    [0, 100]
  ]
}
```

will blacklist the first 101 uid values.