### PR TITLE
Renames default DB filename for clarity

### DIFF
--- a/quota_notifier/settings.py
+++ b/quota_notifier/settings.py
@@ -14,7 +14,7 @@ from pydantic import BaseSettings, Field, validator
 
 from quota_notifier.orm import DBConnection
 
-DEFAULT_DB_PATH = Path.cwd().resolve() / 'app_data.db'
+DEFAULT_DB_PATH = Path.cwd().resolve() / 'notifier_data.db'
 
 
 class FileSystemSchema(BaseSettings):


### PR DESCRIPTION
Renames the default sqlite DB filename from `app_data.db` to `notifier_data.db`. A small change to help improve clarity, particularly when running in crowded/messy directories.