### PR TITLE
Delay DB creation until connection is established

### DIFF
--- a/quota_notifier/main.py
+++ b/quota_notifier/main.py
@@ -48,6 +48,11 @@ class Parser(ArgumentParser):
             '-v', action='count', dest='verbose', default=0,
             help='set output verbosity to warning (-v), info (-vv), or debug (-vvv)')
 
+    def error(self, message: str) -> None:
+        """Exit the application and provide the given message"""
+
+        raise SystemExit(f'{self.prog} error: {message}')
+
 
 class Application:
     """Entry point for instantiating and executing the application"""

--- a/quota_notifier/orm.py
+++ b/quota_notifier/orm.py
@@ -8,7 +8,7 @@ Module Contents
 from __future__ import annotations
 
 import logging
-from typing import Callable
+from typing import Callable, Optional
 
 from sqlalchemy import Column, DateTime, Integer, MetaData, String, UniqueConstraint, create_engine, func
 from sqlalchemy.engine import Connection, Engine
@@ -67,11 +67,11 @@ class DBConnection:
     propagate to the entire parent application.
     """
 
-    connection: Connection = None
     engine: Engine = None
     url: str = None
     metadata: MetaData = Base.metadata
-    session: Callable[[], Session] = None
+    connection: Optional[Connection] = None
+    _session_maker: Callable[[], Session] = None
 
     @classmethod
     def configure(cls, url: str) -> None:
@@ -86,7 +86,19 @@ class DBConnection:
         logging.info(f'Configuring database URL: {url}')
 
         cls.url = url
+        if cls.connection:
+            cls.connection.close()
+
+        cls.connection = None
         cls.engine = create_engine(cls.url)
+        cls._session_maker = sessionmaker(cls.engine)
+
+    @classmethod
+    def session(cls) -> Session:
+        """Connect to the database and return a new database session"""
+
+        if cls.connection is None:
+            cls.connection = cls.engine.connect()
+
         cls.metadata.create_all(cls.engine)
-        cls.connection = cls.engine.connect()
-        cls.session = sessionmaker(cls.engine)
+        return cls._session_maker()

--- a/quota_notifier/orm.py
+++ b/quota_notifier/orm.py
@@ -5,8 +5,6 @@ Module Contents
 ---------------
 """
 
-from __future__ import annotations
-
 import logging
 from typing import Callable, Optional
 

--- a/quota_notifier/orm.py
+++ b/quota_notifier/orm.py
@@ -67,10 +67,9 @@ class DBConnection:
     propagate to the entire parent application.
     """
 
-    engine: Engine = None
     url: str = None
-    metadata: MetaData = Base.metadata
-    connection: Optional[Connection] = None
+    engine: Engine = None
+    _connection: Optional[Connection] = None
     _session_maker: Callable[[], Session] = None
 
     @classmethod
@@ -86,8 +85,8 @@ class DBConnection:
         logging.info(f'Configuring database URL: {url}')
 
         cls.url = url
-        if cls.connection:
-            cls.connection.close()
+        if cls._connection:
+            cls._connection.close()
 
         cls.connection = None
         cls.engine = create_engine(cls.url)
@@ -97,8 +96,8 @@ class DBConnection:
     def session(cls) -> Session:
         """Connect to the database and return a new database session"""
 
-        if cls.connection is None:
+        if cls._connection is None:
             cls.connection = cls.engine.connect()
 
-        cls.metadata.create_all(cls.engine)
+        Base.metadata.create_all(cls.engine)
         return cls._session_maker()

--- a/quota_notifier/orm.py
+++ b/quota_notifier/orm.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import logging
 from typing import Callable, Optional
 
-from sqlalchemy import Column, DateTime, Integer, MetaData, String, UniqueConstraint, create_engine, func
+from sqlalchemy import Column, DateTime, Integer, String, UniqueConstraint, create_engine, func
 from sqlalchemy.engine import Connection, Engine
 from sqlalchemy.orm import Session, declarative_base, sessionmaker, validates
 

--- a/tests/main/test_application.py
+++ b/tests/main/test_application.py
@@ -2,6 +2,7 @@
 
 import json
 import logging
+import os
 from json import JSONDecodeError
 from pathlib import Path
 from tempfile import NamedTemporaryFile
@@ -21,13 +22,13 @@ class SettingsValidation(TestCase):
         """Test ``FileNotFoundError`` is raised when the settings file does not exist"""
 
         with self.assertRaises(FileNotFoundError):
-            Application.run(validate=True, verbose=0, debug=True, settings=Path('fake/file/path.json'))
+            Application.run(validate=True, debug=True, settings=Path('fake/file/path.json'))
 
     def test_error_on_empty_file(self) -> None:
         """Test ``JSONDecodeError`` is raised when the settings file is empty"""
 
         with self.assertRaises(JSONDecodeError), NamedTemporaryFile() as temp:
-            Application.run(validate=True, verbose=0, debug=True, settings=Path(temp.name))
+            Application.run(validate=True, debug=True, settings=Path(temp.name))
 
     def test_error_on_invalid_file(self) -> None:
         """Test ``JSONDecodeError`` is raised when the settings file is not valid json"""
@@ -36,7 +37,7 @@ class SettingsValidation(TestCase):
             with open(temp.name, 'w') as f:
                 f.write('notjson')
 
-            Application.run(validate=True, verbose=0, debug=True, settings=Path(temp.name))
+            Application.run(validate=True, debug=True, settings=Path(temp.name))
 
     def test_error_on_invalid_settings(self) -> None:
         """Test ``ValidationError`` is raised when the settings file has extra settings"""
@@ -45,13 +46,13 @@ class SettingsValidation(TestCase):
             with open(temp.name, 'w') as f:
                 f.write('{"extra": "field"}')
 
-            Application.run(validate=True, verbose=0, debug=True, settings=Path(temp.name))
+            Application.run(validate=True, debug=True, settings=Path(temp.name))
 
     def test_no_error_on_defaults(self) -> None:
         """Test no error is raised when validating the default application settings path"""
 
         self.assertFalse(DEFAULT_SETTINGS_PATH.exists())
-        Application.run(validate=True, verbose=0, debug=True, settings=DEFAULT_SETTINGS_PATH)
+        Application.run(validate=True, debug=True, settings=DEFAULT_SETTINGS_PATH)
 
 
 class VerbosityConfiguration(TestCase):
@@ -85,39 +86,39 @@ class VerbosityConfiguration(TestCase):
     def test_output_format(self):
         """Test the console logging format has been customized"""
 
-        Application.execute(['-v'])
+        Application.execute(['-v', '--debug'])
         log_format = self.get_stream_handler().formatter._fmt
         self.assertEqual('%(levelname)8s - %(message)s', log_format)
 
     def test_verbose_level_zero(self):
         """Test the application is silent by default"""
 
-        Application.execute([])
+        Application.execute(['--debug'])
         with self.assertRaisesRegex(RuntimeError, 'Stream handler not found'):
             self.get_stream_handler()
 
     def test_verbose_level_one(self):
         """Test a single verbose flag sets the logging level to ``WARNING``"""
 
-        Application.execute(['-v'])
+        Application.execute(['-v', '--debug'])
         self.assertEqual(logging.WARNING, self.get_stream_handler().level)
 
     def test_verbose_level_two(self):
         """Test two verbose flags sets the logging level to ``INFO``"""
 
-        Application.execute(['-vv'])
+        Application.execute(['-vv', '--debug'])
         self.assertEqual(logging.INFO, self.get_stream_handler().level)
 
     def test_verbose_level_three(self):
         """Test three verbose flags sets the logging level to ``DEBUG``"""
 
-        Application.execute(['-vvv'])
+        Application.execute(['-vvv', '--debug'])
         self.assertEqual(logging.DEBUG, self.get_stream_handler().level)
 
     def test_verbose_level_many(self):
         """Test several verbose flags sets the logging level to ``DEBUG``"""
 
-        Application.execute(['-vvvvvvvvvv'])
+        Application.execute(['-vvvvvvvvvv', '--debug'])
         self.assertEqual(logging.DEBUG, self.get_stream_handler().level)
 
 
@@ -134,6 +135,7 @@ class DatabaseConfiguration(TestCase):
         """Test the memory URL defaults to the default application settings"""
 
         Application.execute([])
+        os.remove(ApplicationSettings.get('db_url').lstrip('sqlite:'))
         self.assertEqual(ApplicationSettings.get('db_url'), DBConnection.url)
 
     def test_db_matches_custom_settings(self) -> None:

--- a/tests/main/test_application.py
+++ b/tests/main/test_application.py
@@ -4,7 +4,6 @@ import json
 import logging
 import os
 from json import JSONDecodeError
-from pathlib import Path
 from tempfile import NamedTemporaryFile
 from unittest import TestCase
 
@@ -19,34 +18,34 @@ class SettingsValidation(TestCase):
     """Test the validation of application settings files when ``validate=True``"""
 
     def test_error_missing_file(self) -> None:
-        """Test ``FileNotFoundError`` is raised when the settings file does not exist"""
+        """Test ``SystemExit`` is raised when the settings file does not exist"""
 
-        with self.assertRaises(FileNotFoundError):
-            Application.run(validate=True, debug=True, settings=Path('fake/file/path.json'))
+        with self.assertRaisesRegex(SystemExit, 'No settings file at fake/file/path.json'):
+            Application.execute(['--validate', '-s', 'fake/file/path.json'])
 
     def test_error_on_empty_file(self) -> None:
-        """Test ``JSONDecodeError`` is raised when the settings file is empty"""
+        """Test ``SystemExit`` is raised when the settings file is empty"""
 
-        with self.assertRaises(JSONDecodeError), NamedTemporaryFile() as temp:
-            Application.run(validate=True, debug=True, settings=Path(temp.name))
+        with self.assertRaises(SystemExit), NamedTemporaryFile() as temp:
+            Application.execute(['--validate', '-s', temp.name])
 
     def test_error_on_invalid_file(self) -> None:
-        """Test ``JSONDecodeError`` is raised when the settings file is not valid json"""
+        """Test ``SystemExit`` is raised when the settings file is not valid json"""
 
-        with self.assertRaises(JSONDecodeError), NamedTemporaryFile() as temp:
+        with self.assertRaises(SystemExit), NamedTemporaryFile() as temp:
             with open(temp.name, 'w') as f:
                 f.write('notjson')
 
-            Application.run(validate=True, debug=True, settings=Path(temp.name))
+            Application.execute(['--validate', '-s', temp.name])
 
     def test_error_on_invalid_settings(self) -> None:
-        """Test ``ValidationError`` is raised when the settings file has extra settings"""
+        """Test ``SystemExit`` is raised when the settings file has extra settings"""
 
-        with self.assertRaises(ValidationError), NamedTemporaryFile() as temp:
+        with self.assertRaises(SystemExit), NamedTemporaryFile() as temp:
             with open(temp.name, 'w') as f:
                 f.write('{"extra": "field"}')
 
-            Application.run(validate=True, debug=True, settings=Path(temp.name))
+            Application.execute(['--validate', '-s', temp.name])
 
     def test_no_error_on_defaults(self) -> None:
         """Test no error is raised when validating the default application settings path"""

--- a/tests/main/test_application.py
+++ b/tests/main/test_application.py
@@ -18,13 +18,13 @@ class SettingsValidation(TestCase):
         """Test ``SystemExit`` is raised when the settings file does not exist"""
 
         with self.assertRaisesRegex(SystemExit, 'No settings file at fake/file/path.json'):
-            Application.execute(['--validate', '-s', 'fake/file/path.json'])
+            Application.execute(['--debug', '--validate', '-s', 'fake/file/path.json'])
 
     def test_error_on_empty_file(self) -> None:
         """Test ``SystemExit`` is raised when the settings file is empty"""
 
         with self.assertRaises(SystemExit), NamedTemporaryFile() as temp:
-            Application.execute(['--validate', '-s', temp.name])
+            Application.execute(['--debug', '--validate', '-s', temp.name])
 
     def test_error_on_invalid_file(self) -> None:
         """Test ``SystemExit`` is raised when the settings file is not valid json"""
@@ -33,7 +33,7 @@ class SettingsValidation(TestCase):
             with open(temp.name, 'w') as f:
                 f.write('notjson')
 
-            Application.execute(['--validate', '-s', temp.name])
+            Application.execute(['--debug', '--validate', '-s', temp.name])
 
     def test_error_on_invalid_settings(self) -> None:
         """Test ``SystemExit`` is raised when the settings file has extra settings"""
@@ -42,7 +42,7 @@ class SettingsValidation(TestCase):
             with open(temp.name, 'w') as f:
                 f.write('{"extra": "field"}')
 
-            Application.execute(['--validate', '-s', temp.name])
+            Application.execute(['--debug', '--validate', '-s', temp.name])
 
     def test_no_error_on_defaults(self) -> None:
         """Test no error is raised when validating the default application settings path"""
@@ -82,14 +82,14 @@ class VerbosityConfiguration(TestCase):
     def test_output_format(self):
         """Test the console logging format has been customized"""
 
-        Application.execute(['-v', '--debug'])
+        Application.execute(['--debug', '-v', '--debug'])
         log_format = self.get_stream_handler().formatter._fmt
         self.assertEqual('%(levelname)8s - %(message)s', log_format)
 
     def test_verbose_level_zero(self):
         """Test the application is silent by default"""
 
-        Application.execute([])
+        Application.execute(['--debug'])
         self.assertEqual(100, self.get_stream_handler().level)
 
     def test_verbose_level_one(self):

--- a/tests/main/test_application.py
+++ b/tests/main/test_application.py
@@ -57,11 +57,6 @@ class SettingsValidation(TestCase):
 class VerbosityConfiguration(TestCase):
     """Test the application verbosity"""
 
-    def setUp(self) -> None:
-        """Reset application settings to defaults"""
-
-        ApplicationSettings.reset_defaults()
-
     @classmethod
     def tearDownClass(cls) -> None:
         """Reset application settings to defaults"""
@@ -139,10 +134,6 @@ class DatabaseConfiguration(TestCase):
         """Test the memory URL defaults to the default application settings"""
 
         Application.execute([])
-
-        # Remove the empty DB file generated automatically by application.execute
-        Path(ApplicationSettings.get('db_url').lstrip('sqlite:')).unlink()
-
         self.assertEqual(ApplicationSettings.get('db_url'), DBConnection.url)
 
     def test_db_matches_custom_settings(self) -> None:

--- a/tests/main/test_application.py
+++ b/tests/main/test_application.py
@@ -3,11 +3,8 @@
 import json
 import logging
 import os
-from json import JSONDecodeError
 from tempfile import NamedTemporaryFile
 from unittest import TestCase
-
-from pydantic import ValidationError
 
 from quota_notifier.main import Application, DEFAULT_SETTINGS_PATH
 from quota_notifier.orm import DBConnection

--- a/tests/orm/test_dbconnection.py
+++ b/tests/orm/test_dbconnection.py
@@ -9,29 +9,21 @@ from quota_notifier.orm import DBConnection
 class DBConfiguration(TestCase):
     """Test the configuration of the DB connection via the ``configure`` method"""
 
-    def test_connection_is_configured(self) -> None:
-        """Test class attributes are set to reflect DB configuration"""
+    def test_engine_is_configured(self) -> None:
+        """Test the DB engine reflects the DB configuration"""
 
-        # Use a temporary file to ensure we are using a unique URL
         with NamedTemporaryFile(suffix='._db') as temp:
             custom_url = f'sqlite:///{temp.name}'
             DBConnection.configure(custom_url)
-            DBConnection.session()  # Calling session establishes a connection with the DB
+            session = DBConnection.session()  # Calling session establishes a connection with the DB
 
         # Make sure the DB engine is pointing to the new URL
-        self.assertIsNotNone(DBConnection.url)
         self.assertEqual(custom_url, DBConnection.url, '`DBConnection.url` not set to correct URL')
-
-        self.assertIsNotNone(DBConnection.engine)
         self.assertEqual(
             custom_url, DBConnection.engine.url.render_as_string(),
             'Incorrect URL for `engine` attribute')
 
-        self.assertIsNotNone(DBConnection.connection)
+        # Make sure session objects are tied to the correct engine
         self.assertEqual(
-            DBConnection.engine, DBConnection.connection.engine,
-            '`DBConnection.connection` bound to incorrect engine')
-
-        self.assertEqual(
-            DBConnection.engine, DBConnection.session().get_bind(),
+            DBConnection.engine, session.get_bind(),
             '`DBConnection.session` bound to incorrect engine')

--- a/tests/orm/test_dbconnection.py
+++ b/tests/orm/test_dbconnection.py
@@ -16,6 +16,7 @@ class DBConfiguration(TestCase):
         with NamedTemporaryFile(suffix='._db') as temp:
             custom_url = f'sqlite:///{temp.name}'
             DBConnection.configure(custom_url)
+            DBConnection.session()  # Calling session establishes a connection with the DB
 
         # Make sure the DB engine is pointing to the new URL
         self.assertIsNotNone(DBConnection.url)
@@ -31,7 +32,6 @@ class DBConfiguration(TestCase):
             DBConnection.engine, DBConnection.connection.engine,
             '`DBConnection.connection` bound to incorrect engine')
 
-        self.assertIsNotNone(DBConnection.session)
         self.assertEqual(
-            DBConnection.engine, DBConnection.session.kw['bind'],
+            DBConnection.engine, DBConnection.session().get_bind(),
             '`DBConnection.session` bound to incorrect engine')


### PR DESCRIPTION
The utility will automatically set up a new DB if it does not already exist. This PR delays that action until a DB session is called for.

Resolves #173 