### PR TITLE
Fixes bug where messages are not logged to console

### DIFF
--- a/quota_notifier/main.py
+++ b/quota_notifier/main.py
@@ -60,14 +60,17 @@ class Application:
             verbosity: Number of commandline verbosity flags
         """
 
+        # Set the root logging level to log everything
+        # Apply additional filtering at the handler level
         app_logger = logging.getLogger()
+        app_logger.setLevel(0)
 
         # Remove any old stream loggers
         for handler in app_logger.handlers:
             if isinstance(handler, logging.StreamHandler):
                 app_logger.removeHandler(handler)
 
-        verbosity = {0: None, 1: 'WARNING', 2: 'INFO', 3: 'DEBUG'}.get(verbosity, 'DEBUG')
+        verbosity = {0: 'ERROR', 1: 'WARNING', 2: 'INFO', 3: 'DEBUG'}.get(verbosity, 'DEBUG')
 
         # Set the verbosity for console outputs
         if verbosity is not None:
@@ -149,4 +152,5 @@ class Application:
             )
 
         except Exception as caught:
-            parser.error(str(caught))
+            err_string = str(caught).replace('\n', ' ')
+            logging.critical(err_string)

--- a/quota_notifier/settings.py
+++ b/quota_notifier/settings.py
@@ -117,9 +117,9 @@ class SettingsSchema(BaseSettings):
         description='Give up on checking a file system after the given number of seconds.')
 
     # Settings for application logging
-    log_level: Literal['DEBUG', 'INFO', 'WARNING'] = Field(
+    log_level: Literal['DEBUG', 'INFO', 'WARNING', 'ERROR'] = Field(
         title='Logging Level',
-        type=Literal['DEBUG', 'INFO', 'WARNING'],
+        type=Literal['DEBUG', 'INFO', 'WARNING', 'ERROR'],
         default='INFO',
         description='Application logging level.')
 

--- a/tests/main/test_application.py
+++ b/tests/main/test_application.py
@@ -98,8 +98,7 @@ class VerbosityConfiguration(TestCase):
         """Test the application is silent by default"""
 
         Application.execute([])
-        with self.assertRaisesRegex(RuntimeError, 'Stream handler not found'):
-            self.get_stream_handler()
+        self.assertEqual(100, self.get_stream_handler().level)
 
     def test_verbose_level_one(self):
         """Test a single verbose flag sets the logging level to ``WARNING``"""


### PR DESCRIPTION
The logging levels were being set correctly at the handler level, but not at the root logger level. This caused log messages to not be properly passed along.