### PR TITLE
Drop settings option from commandline

### DIFF
--- a/docs/source/getting_started/usage.rst
+++ b/docs/source/getting_started/usage.rst
@@ -35,19 +35,13 @@ All ID ranges are treated as being inclusive.
 Validate Application Settings
 -----------------------------
 
-By default, the application looks for application settings at ``/etc/notifier/settings.json``.
-This path can be customized via the ``-s`` argument:
-
-.. code-block::
-
-      notifier -s [SETTINGS-PATH]
-
+Application settings can be customized via the ``/etc/notifier/settings.json`` file.
 The ``notifier`` utility will automatically validate the application settings file before issuing email notifications.
 However, the settings file can be validated without issuing email notifications by setting the ``--validate`` flag:
 
 .. code-block:: bash
 
-   notifier -s [SETTINGS-PATH] --validate
+   notifier --validate
 
 If the settings are valid, the application will exit silently.
 Otherwise, an error message will detail the invalid settings.

--- a/docs/source/overview/installation.rst
+++ b/docs/source/overview/installation.rst
@@ -24,7 +24,7 @@ The ``notifier`` command line utility is installable via the `pip <https://pip.p
 Configuration
 -------------
 
-Application settings are configurable via JSON settings file.
+Application settings are configurable via a settings file at ``/etc/notifier/settings.json``.
 The example below includes a minimal subset of useful settings to get up and running.
 A full list of available settings is provided in the :doc:`configuration` page.
 
@@ -38,9 +38,6 @@ A full list of available settings is provided in the :doc:`configuration` page.
        "uid_blacklist": [0],
        "gid_blacklist": [0]
    }
-
-By default, the application looks for the settings file at ``/etc/notifier/settings.json``.
-This path can also be changed at runtime (see the :doc:`../getting_started/usage` page for more information).
 
 Once the application has been configured, you can check the configuration file is valid by running:
 

--- a/tests/main/test_application.py
+++ b/tests/main/test_application.py
@@ -1,54 +1,12 @@
 """Tests for the ``Application`` class."""
 
-import json
 import logging
 import os
-from tempfile import NamedTemporaryFile
 from unittest import TestCase
 
-from quota_notifier.main import Application, DEFAULT_SETTINGS_PATH
+from quota_notifier.main import Application
 from quota_notifier.orm import DBConnection
 from quota_notifier.settings import ApplicationSettings
-
-
-class SettingsValidation(TestCase):
-    """Test the validation of application settings files when ``validate=True``"""
-
-    def test_error_missing_file(self) -> None:
-        """Test ``SystemExit`` is raised when the settings file does not exist"""
-
-        with self.assertRaisesRegex(SystemExit, 'No settings file at fake/file/path.json'):
-            Application.execute(['--debug', '--validate', '-s', 'fake/file/path.json'])
-
-    def test_error_on_empty_file(self) -> None:
-        """Test ``SystemExit`` is raised when the settings file is empty"""
-
-        with self.assertRaises(SystemExit), NamedTemporaryFile() as temp:
-            Application.execute(['--debug', '--validate', '-s', temp.name])
-
-    def test_error_on_invalid_file(self) -> None:
-        """Test ``SystemExit`` is raised when the settings file is not valid json"""
-
-        with self.assertRaises(SystemExit), NamedTemporaryFile() as temp:
-            with open(temp.name, 'w') as f:
-                f.write('notjson')
-
-            Application.execute(['--debug', '--validate', '-s', temp.name])
-
-    def test_error_on_invalid_settings(self) -> None:
-        """Test ``SystemExit`` is raised when the settings file has extra settings"""
-
-        with self.assertRaises(SystemExit), NamedTemporaryFile() as temp:
-            with open(temp.name, 'w') as f:
-                f.write('{"extra": "field"}')
-
-            Application.execute(['--debug', '--validate', '-s', temp.name])
-
-    def test_no_error_on_defaults(self) -> None:
-        """Test no error is raised when validating the default application settings path"""
-
-        self.assertFalse(DEFAULT_SETTINGS_PATH.exists())
-        Application.run(validate=True, debug=True, settings=DEFAULT_SETTINGS_PATH)
 
 
 class VerbosityConfiguration(TestCase):
@@ -132,16 +90,3 @@ class DatabaseConfiguration(TestCase):
         Application.execute([])
         os.remove(ApplicationSettings.get('db_url').lstrip('sqlite:'))
         self.assertEqual(ApplicationSettings.get('db_url'), DBConnection.url)
-
-    def test_db_matches_custom_settings(self) -> None:
-        """Test the memory URL is updated to reflect custom application settings"""
-
-        with NamedTemporaryFile(suffix='.db') as temp_db, NamedTemporaryFile(suffix='.json') as temp_settings:
-            # Generate a custom settings file pointing at a custom DB path
-            settings_str = json.dumps({'db_url': f'sqlite:///{temp_db.name}'})
-            with open(temp_settings.name, 'w') as f:
-                f.write(settings_str)
-
-            # Check the DB url matches the custom DB path
-            Application.execute(['-s', temp_settings.name])
-            self.assertEqual(f'sqlite:///{temp_db.name}', DBConnection.url)

--- a/tests/main/test_parser.py
+++ b/tests/main/test_parser.py
@@ -1,9 +1,8 @@
 """Tests for the ``Parser`` class."""
 
-from pathlib import Path
 from unittest import TestCase
 
-from quota_notifier.main import DEFAULT_SETTINGS_PATH, Parser
+from quota_notifier.main import Parser
 
 
 class ParserHelpData(TestCase):
@@ -18,25 +17,6 @@ class ParserHelpData(TestCase):
         """Test the application description is not empty"""
 
         self.assertTrue(Parser().description)
-
-
-class SettingsOption(TestCase):
-    """Test parsing of the ``--settings`` option"""
-
-    def test_default_config_path(self) -> None:
-        """Test the default settings path matches globally defined values"""
-
-        args = Parser().parse_args([])
-        self.assertEqual(DEFAULT_SETTINGS_PATH, args.settings)
-
-    def test_stored_as_path(self) -> None:
-        """Test the parsed value is stored as a ``Path`` object"""
-
-        test_path_str = '/my/test/path'
-        test_path_obj = Path(test_path_str)
-
-        args = Parser().parse_args(['-s', test_path_str])
-        self.assertEqual(test_path_obj, args.settings)
 
 
 class ValidateOption(TestCase):


### PR DESCRIPTION
The `-s` option was useful during preliminary development, but I don't expect it to be very useful in production.