### PR TITLE
Automatically configure application settings on package import

### DIFF
--- a/quota_notifier/__init__.py
+++ b/quota_notifier/__init__.py
@@ -30,4 +30,9 @@ a threshold before exceeding the threshold a second time.
 
 import importlib.metadata
 
+from .settings import ApplicationSettings as _settings
+
 __version__ = importlib.metadata.version(__package__)
+
+# Automatically configure default application settings
+_settings.reset_defaults()

--- a/quota_notifier/settings.py
+++ b/quota_notifier/settings.py
@@ -230,7 +230,7 @@ class ApplicationSettings:
     Use the ``configure_from_file`` method to load settings from a settings file.
     """
 
-    _parsed_settings: SettingsSchema = SettingsSchema()
+    _parsed_settings: SettingsSchema = None
 
     @classmethod
     def _configure_logging(cls) -> None:


### PR DESCRIPTION
Calls `ApplicationSettings.reset_defaults` at package import. This ensures application configuration (`ApplicationSettings._configure_application`) is called behind the scenes before any application logic executes.

This hasn't been a problem thus far because the settings are modified by the CLI application even when running against default settings. As a design point, we shouldn't take for granted the application settings are modified from defaults every time  the CLI runs.