### PR TITLE
Add support for file system specific thresholds

### DIFF
--- a/docs/source/overview/installation.rst
+++ b/docs/source/overview/installation.rst
@@ -41,7 +41,7 @@ A full list of available settings is provided in the :doc:`configuration` page.
                "name": "Example File System",
                "path": "/example",
                "type": "generic",
-               "thresholds": [75, 100]
+               "thresholds": [50, 75]
            }
        ]
    }

--- a/docs/source/overview/installation.rst
+++ b/docs/source/overview/installation.rst
@@ -34,9 +34,16 @@ A full list of available settings is provided in the :doc:`configuration` page.
        "log_path": "/home/notifier.log",
        "log_level": "INFO",
        "db_url": "sqlite:///home/notifier_data.db",
-       "thresholds": [75, 100],
        "uid_blacklist": [0],
-       "gid_blacklist": [0]
+       "gid_blacklist": [0],
+       "file_systems": [
+           {
+               "name": "Example File System",
+               "path": "/example",
+               "type": "generic",
+               "thresholds": [75, 100]
+           }
+       ]
    }
 
 Once the application has been configured, you can check the configuration file is valid by running:

--- a/quota_notifier/notify.py
+++ b/quota_notifier/notify.py
@@ -148,6 +148,8 @@ class UserNotifier:
     def get_last_threshold(session: Session, quota: AbstractQuota) -> Optional[int]:
         """Return the last threshold a user was notified for
 
+        If no previous notification history can be found, the return calue is None
+
         Args:
             session: Active database session for performing select queries
             quota: The quota to get a threshold for
@@ -170,6 +172,9 @@ class UserNotifier:
     @staticmethod
     def get_next_threshold(quota: AbstractQuota) -> Optional[int]:
         """Return the next threshold a user should be notified for
+
+        The return value will be less than or equal to the current quota usage.
+        If there is no notification threshold less than the current usage, the return value is None.
 
         Args:
             quota: The quota to get a threshold for

--- a/quota_notifier/notify.py
+++ b/quota_notifier/notify.py
@@ -180,7 +180,7 @@ class UserNotifier:
 
         # Get the notification thresholds for the given file system quota
         file_systems = ApplicationSettings.get('file_systems')
-        thresholds = next(fs.hresholds for fs in file_systems if fs.name == quota.name)
+        thresholds = next(fs.thresholds for fs in file_systems if fs.name == quota.name)
 
         next_threshold = None
         if quota.percentage >= min(thresholds):

--- a/quota_notifier/notify.py
+++ b/quota_notifier/notify.py
@@ -178,8 +178,11 @@ class UserNotifier:
             The largest notification threshold that is less than the current usage or None
         """
 
+        # Get the notification thresholds for the given file system quota
+        file_systems = ApplicationSettings.get('file_systems')
+        thresholds = next(fs.hresholds for fs in file_systems if fs.name == quota.name)
+
         next_threshold = None
-        thresholds = ApplicationSettings.get('thresholds')
         if quota.percentage >= min(thresholds):
             index = bisect_right(thresholds, quota.percentage)
             next_threshold = thresholds[index - 1]

--- a/quota_notifier/settings.py
+++ b/quota_notifier/settings.py
@@ -42,7 +42,6 @@ class FileSystemSchema(BaseSettings):
     thresholds: List[int] = Field(
         title='Notification Thresholds',
         type=List[int],
-        default=[90, ],
         description='Usage percentages to issue notifications for.')
 
     @validator('name')

--- a/quota_notifier/settings.py
+++ b/quota_notifier/settings.py
@@ -39,6 +39,12 @@ class FileSystemSchema(BaseSettings):
         type=Literal['ihome', 'generic', 'beegfs'],
         description='Type of the file system')
 
+    thresholds: List[int] = Field(
+        title='Notification Thresholds',
+        type=List[int],
+        default=[90, ],
+        description='Usage percentages to issue notifications for.')
+
     @validator('name')
     def validate_name(cls, value: str) -> str:
         """Ensure the given name is not blank
@@ -75,6 +81,23 @@ class FileSystemSchema(BaseSettings):
 
         return value
 
+    @validator('thresholds')
+    def validate_thresholds(cls, value: int) -> int:
+        """Validate threshold values are between 0 and 100 (exclusive)
+
+        Args:
+            value: The threshold value to validate
+
+        Returns:
+            The validated threshold value
+        """
+
+        for threshold in value:
+            if not (100 > threshold > 0):
+                raise ValueError(f'Notification threshold {threshold} must be greater than 0 and less than 100')
+
+        return value
+
 
 class SettingsSchema(BaseSettings):
     """Defines the schema and default values for top level application settings"""
@@ -85,12 +108,6 @@ class SettingsSchema(BaseSettings):
         type=Path,
         default=Path('/ihome/crc/scripts/ihome_quota.json'),
         description='Path to ihome storage information.')
-
-    thresholds: List[int] = Field(
-        title='Notification Thresholds',
-        type=List[int],
-        default=[98, 100],
-        description='Usage percentages to issue notifications for.')
 
     file_systems: List[FileSystemSchema] = Field(
         title='Monitored File Systems',

--- a/quota_notifier/settings.py
+++ b/quota_notifier/settings.py
@@ -95,7 +95,7 @@ class FileSystemSchema(BaseSettings):
             raise ValueError(f'At least one threshold must be specified per file system')
 
         for threshold in value:
-            if not (100 > threshold > 0):
+            if not 100 > threshold > 0:
                 raise ValueError(f'Notification threshold {threshold} must be greater than 0 and less than 100')
 
         return value

--- a/quota_notifier/settings.py
+++ b/quota_notifier/settings.py
@@ -81,15 +81,18 @@ class FileSystemSchema(BaseSettings):
         return value
 
     @validator('thresholds')
-    def validate_thresholds(cls, value: int) -> int:
+    def validate_thresholds(cls, value: list) -> list:
         """Validate threshold values are between 0 and 100 (exclusive)
 
         Args:
-            value: The threshold value to validate
+            value: List of threshold values to validate
 
         Returns:
-            The validated threshold value
+            The validated threshold values
         """
+
+        if not value:
+            raise ValueError(f'At least one threshold must be specified per file system')
 
         for threshold in value:
             if not (100 > threshold > 0):

--- a/tests/notify/test_usernotifier.py
+++ b/tests/notify/test_usernotifier.py
@@ -16,7 +16,7 @@ from quota_notifier.shell import User
 
 
 class GetUsers(TestCase):
-    """Test the fetching of usernames to notify"""
+    """Test the ``get_users`` method"""
 
     def tearDown(self) -> None:
         """Reset any modifications to application settings after each test"""

--- a/tests/notify/test_usernotifier.py
+++ b/tests/notify/test_usernotifier.py
@@ -69,7 +69,7 @@ class GetUserQuotas(TestCase):
 
         # Register the current directory with the application
         self.current_dir = Path(__file__).parent
-        self.mock_file_system = FileSystemSchema(name='test', path=self.current_dir, type='generic')
+        self.mock_file_system = FileSystemSchema(name='test', path=self.current_dir, type='generic', thresholds=[50])
         ApplicationSettings.set(file_systems=[self.mock_file_system])
 
         # Create a subdirectory matching the current user's group

--- a/tests/notify/test_usernotifier.py
+++ b/tests/notify/test_usernotifier.py
@@ -135,13 +135,15 @@ class GetLastThreshold(TestCase):
         self.assertEqual(test_threshold, threshold)
 
 
-# TODO: Update docs for methods
-# TODO: Check behavior enforced by the last two tests is what we want
 class GetNextThreshold(TestCase):
     """Test determination of the next notification threshold"""
 
     def setUp(self) -> None:
-        """Restore default application settings and run tests against a temporary DB in memory"""
+        """Set up testing constructs against a temporary DB in memory
+
+        Configures a single file system in application settings called test with
+        notification thresholds at 50 and 75 percent.
+        """
 
         ApplicationSettings.reset_defaults()
         ApplicationSettings.set(db_url='sqlite:///:memory:')

--- a/tests/notify/test_usernotifier.py
+++ b/tests/notify/test_usernotifier.py
@@ -219,9 +219,11 @@ class NotificationHistory(TestCase):
         ApplicationSettings.reset_defaults()
         ApplicationSettings.set(db_url='sqlite:///:memory:')
 
+        # Reusable database query for fetching user info
         self.mock_user = User('mock')
         self.query = select(Notification).where(Notification.username == self.mock_user.username)
 
+        # Configure a mock file system with the parent applicaion
         self.mock_file_system = FileSystemSchema(name='test', path='/', type='generic', thresholds=[50, 75])
         ApplicationSettings.set(file_systems=[self.mock_file_system])
 
@@ -300,7 +302,6 @@ class NotificationHistory(TestCase):
         self.run_application(usage=lowest_threshold)
 
         # Check the notification history was updated
-
         with DBConnection.session() as session:
             db_record = session.execute(self.query).scalars().first()
             self.assertEqual(lowest_threshold, db_record.threshold)

--- a/tests/settings/test_filesystemschema.py
+++ b/tests/settings/test_filesystemschema.py
@@ -62,3 +62,38 @@ class TypeValidation(TestCase):
 
         with self.assertRaisesRegex(ValidationError, 'type\n  unexpected value;'):
             FileSystemSchema(type='fake_type')
+
+
+class ThresholdValidation(TestCase):
+    """Test validation of the ``threshold`` field"""
+
+    def test_intermediate_values_apss(self) -> None:
+        """Test values greater than 0 and less than 100 pass validation"""
+
+        test_thresholds = [1, 25, 50, 75, 99]
+        validated_value = FileSystemSchema.validate_thresholds(test_thresholds)
+        self.assertCountEqual(test_thresholds, validated_value)
+
+    def test_zero_percent(self) -> None:
+        """Test the value ``0`` fails validation"""
+
+        with self.assertRaisesRegex(ValidationError, 'must be greater than 0 and less than 100'):
+            FileSystemSchema(thresholds=[0, 50])
+
+    def test_100_percent(self) -> None:
+        """Test the value ``100`` fails validation"""
+
+        with self.assertRaisesRegex(ValidationError, 'must be greater than 0 and less than 100'):
+            FileSystemSchema(thresholds=[50, 100])
+
+    def test_negative_percent(self) -> None:
+        """Test negative values fail validation"""
+
+        with self.assertRaisesRegex(ValidationError, 'must be greater than 0 and less than 100'):
+            FileSystemSchema(thresholds=[-1, 50])
+
+    def test_over_100_percent(self) -> None:
+        """Test values over ``100`` fail validation"""
+
+        with self.assertRaisesRegex(ValidationError, 'must be greater than 0 and less than 100'):
+            FileSystemSchema(thresholds=[50, 101])

--- a/tests/settings/test_filesystemschema.py
+++ b/tests/settings/test_filesystemschema.py
@@ -67,12 +67,18 @@ class TypeValidation(TestCase):
 class ThresholdValidation(TestCase):
     """Test validation of the ``threshold`` field"""
 
-    def test_intermediate_values_apss(self) -> None:
+    def test_intermediate_values_pass(self) -> None:
         """Test values greater than 0 and less than 100 pass validation"""
 
         test_thresholds = [1, 25, 50, 75, 99]
         validated_value = FileSystemSchema.validate_thresholds(test_thresholds)
         self.assertCountEqual(test_thresholds, validated_value)
+
+    def test_empty_list_fails(self) -> None:
+        """Test an empty collection of thresholds fails validation"""
+
+        with self.assertRaisesRegex(ValidationError, 'At least one threshold must be specified'):
+            FileSystemSchema(thresholds=[])
 
     def test_zero_percent(self) -> None:
         """Test the value ``0`` fails validation"""

--- a/tests/settings/test_filesystemschema.py
+++ b/tests/settings/test_filesystemschema.py
@@ -26,8 +26,8 @@ class NameValidation(TestCase):
     def test_whitespace_is_stripped(self) -> None:
         """Test leading/trailing whitespace is stripped from filesystem names"""
 
-        file_system = FileSystemSchema(name=' abc ', path='/', type='generic')
-        self.assertEqual('abc', file_system.name)
+        validated_name = FileSystemSchema.validate_name(' abc ')
+        self.assertEqual('abc', validated_name)
 
 
 class PathValidation(TestCase):
@@ -55,7 +55,7 @@ class TypeValidation(TestCase):
         """Test valid types do not raise errors"""
 
         for fs_type in QuotaFactory.QuotaType:
-            FileSystemSchema(name='name', type=fs_type.name, path='/')
+            FileSystemSchema(name='name', type=fs_type.name, path='/', thresholds=[50])
 
     def test_invalid_type_error(self) -> None:
         """Test a ``ValueError`` is raised for invalid types"""

--- a/tests/settings/test_settingsschema.py
+++ b/tests/settings/test_settingsschema.py
@@ -45,8 +45,8 @@ class FileSystemValidation(TestCase):
         """Test a ``ValueError`` is raised when file systems have duplicate paths"""
 
         # Test objects have different names but the same path
-        system_1 = FileSystemSchema(name='name1', path=Path('/'), type='generic')
-        system_2 = FileSystemSchema(name='name2', path=system_1.path, type='generic')
+        system_1 = FileSystemSchema(name='name1', path=Path('/'), type='generic', thresholds=[50])
+        system_2 = FileSystemSchema(name='name2', path=system_1.path, type='generic', thresholds=[50])
 
         with self.assertRaisesRegex(ValueError, 'File systems do not have unique paths'):
             SettingsSchema.validate_unique_file_systems([system_1, system_2])
@@ -56,8 +56,8 @@ class FileSystemValidation(TestCase):
 
         with tempfile.TemporaryDirectory() as tempdir1, tempfile.TemporaryDirectory() as tempdir2:
             # Test objects have different names but the same path
-            system_1 = FileSystemSchema(name='name', path=Path(tempdir1), type='generic')
-            system_2 = FileSystemSchema(name=system_1.name, path=Path(tempdir2), type='generic')
+            system_1 = FileSystemSchema(name='name', path=Path(tempdir1), type='generic', thresholds=[50])
+            system_2 = FileSystemSchema(name=system_1.name, path=Path(tempdir2), type='generic', thresholds=[50])
 
             with self.assertRaisesRegex(ValueError, 'File systems do not have unique names'):
                 SettingsSchema.validate_unique_file_systems([system_1, system_2])
@@ -65,7 +65,7 @@ class FileSystemValidation(TestCase):
     def test_valid_values_returned(self) -> None:
         """Test valid values are returned by the validator"""
 
-        valid_input = [FileSystemSchema(name='name1', path=Path('/'), type='generic')]
+        valid_input = [FileSystemSchema(name='name1', path=Path('/'), type='generic', thresholds=[50])]
         returned_value = SettingsSchema.validate_unique_file_systems(valid_input)
         self.assertEqual(valid_input, returned_value)
 


### PR DESCRIPTION
The `thresholds` setting has been moved into the file system definitions. This allows different file systems to have different notification thresholds.