### PR TITLE
Adds log page to documentation

### DIFF
--- a/docs/source/source_docs/log.rst
+++ b/docs/source/source_docs/log.rst
@@ -1,0 +1,4 @@
+quota_notifier.log
+------------------
+
+.. automodule:: quota_notifier.log


### PR DESCRIPTION
A documentation page is missing for the log module. This PR adds it.