### PR TITLE
Move application configuration to Application class

### DIFF
--- a/quota_notifier/settings.py
+++ b/quota_notifier/settings.py
@@ -282,6 +282,9 @@ class ApplicationSettings:
     def get(cls, item: str) -> Any:
         """Return a value from application settings
 
+        Valid arguments include any attribute name for the
+        ``SettingsSchema`` class.
+
         Args:
             item: Name of the settings value to retrieve
 

--- a/quota_notifier/settings.py
+++ b/quota_notifier/settings.py
@@ -14,9 +14,6 @@ from typing import Any, List, Union, Tuple, Set, Optional, Literal
 
 from pydantic import BaseSettings, Field, validator
 
-from .log import configure_log_file
-from .orm import DBConnection
-
 DEFAULT_DB_PATH = Path.cwd().resolve() / 'notifier_data.db'
 
 
@@ -237,33 +234,6 @@ class ApplicationSettings:
     _parsed_settings: SettingsSchema = None
 
     @classmethod
-    def _configure_logging(cls) -> None:
-        """Configure python logging to the given level"""
-
-        log_path = cls.get('log_path')
-        log_level = cls.get('log_level')
-        if log_path is not None:
-            configure_log_file(log_level, log_path)
-
-    @classmethod
-    def _configure_database(cls) -> None:
-        """Configure the application database connection"""
-
-        if cls.get('debug'):
-            logging.warning('Running in debug mode')
-            DBConnection.configure('sqlite:///:memory:')
-
-        else:
-            DBConnection.configure(cls.get('db_url'))
-
-    @classmethod
-    def _configure_application(cls):
-        """Update backend application constructs to reflect current application settings"""
-
-        cls._configure_logging()
-        cls._configure_database()
-
-    @classmethod
     def set_from_file(cls, path: Path) -> None:
         """Reset application settings to default values
 
@@ -277,7 +247,6 @@ class ApplicationSettings:
 
         try:
             cls._parsed_settings = SettingsSchema.parse_file(path)
-            cls._configure_application()
 
         except Exception:
             logging.error('settings file is invalid')
@@ -303,14 +272,11 @@ class ApplicationSettings:
 
             setattr(cls._parsed_settings, item, value)
 
-        cls._configure_application()
-
     @classmethod
     def reset_defaults(cls) -> None:
         """Reset application settings to default values"""
 
         cls._parsed_settings = SettingsSchema()
-        cls._configure_application()
 
     @classmethod
     def get(cls, item: str) -> Any:

--- a/tests/cli/test_application.py
+++ b/tests/cli/test_application.py
@@ -4,8 +4,8 @@ import logging
 import os
 from unittest import TestCase
 
-from quota_notifier.log import console_logger
 from quota_notifier.cli import Application
+from quota_notifier.log import console_logger
 from quota_notifier.orm import DBConnection
 from quota_notifier.settings import ApplicationSettings
 

--- a/tests/settings/test_applicationsettings.py
+++ b/tests/settings/test_applicationsettings.py
@@ -1,15 +1,12 @@
 """Tests for the ``ApplicationSettings`` class"""
 
 import json
-import logging
 from pathlib import Path
 from tempfile import NamedTemporaryFile
 from unittest import TestCase
 
 from pydantic import ValidationError
 
-from quota_notifier.log import file_logger
-from quota_notifier.orm import DBConnection
 from quota_notifier.settings import ApplicationSettings
 
 
@@ -42,28 +39,6 @@ class ResetDefaults(TestCase):
         ApplicationSettings.set(uid_blacklist=[1])
         ApplicationSettings.reset_defaults()
         self.assertEqual({0, }, ApplicationSettings.get('uid_blacklist'))
-
-    def test_database_connection_is_reconfigured(self) -> None:
-        """Test the database connection is reconfigured after resetting defaults"""
-
-        # Change the DB URL and then reset it to the default
-        with NamedTemporaryFile() as temp_file:
-            tem_db_path = f'sqlite:///{Path(temp_file.name).resolve()}'
-            ApplicationSettings.set(db_url=tem_db_path)
-
-            ApplicationSettings.reset_defaults()
-            self.assertEqual(ApplicationSettings.get('db_url'), DBConnection.url)
-
-    def test_logging_is_reconfigured(self) -> None:
-        """Test logging is reconfigured to ignore log files"""
-
-        with NamedTemporaryFile(suffix='.log') as temp_log_file:
-            ApplicationSettings.set(log_path=temp_log_file.name)
-            ApplicationSettings.reset_defaults()
-
-            self.assertIsNone(ApplicationSettings.get('log_path'))
-            for handler in file_logger.handlers:
-                self.assertGreaterEqual(1000, handler.level)
 
 
 class ConfigureFromFile(TestCase):
@@ -111,71 +86,3 @@ class Set(TestCase):
 
         with self.assertRaises(ValueError):
             ApplicationSettings.set(fakesetting=1)
-
-    def test_db_is_configured(self):
-        """Test the database connection is reconfigured after updating settings"""
-
-        # Change the DB URL and then reset it to the default
-        with NamedTemporaryFile() as temp_file:
-            tem_db_path = f'sqlite:///{Path(temp_file.name).resolve()}'
-            ApplicationSettings.set(db_url=tem_db_path)
-            self.assertEqual(tem_db_path, DBConnection.url)
-
-
-class LoggingConfiguration(TestCase):
-    """Test the configuration of application logging"""
-
-    def setUp(self) -> None:
-        """Reset application settings to defaults"""
-
-        ApplicationSettings.reset_defaults()
-
-    @classmethod
-    def tearDownClass(cls) -> None:
-        """Reset application settings to defaults"""
-
-        ApplicationSettings.reset_defaults()
-
-    def test_no_logger_by_default(self) -> None:
-        """Test a file logger is not configured by default"""
-
-        self.assertIsNone(ApplicationSettings.get('log_path'))
-        for handler in file_logger.handlers:
-            self.assertGreaterEqual(1000, handler.level)
-
-    def test_logging_level(self):
-        """Test the logging level is updated to reflect application settings"""
-
-        for level in ('DEBUG', 'INFO', 'WARNING', 'ERROR'):
-            with NamedTemporaryFile(suffix='.log') as temp_log_file:
-                ApplicationSettings.set(log_path=temp_log_file.name, log_level=level)
-
-                for handler in file_logger.handlers:
-                    handler_level_str = logging.getLevelName(handler.level)
-                    self.assertEqual(level, handler_level_str)
-
-
-class DatabaseConfiguration(TestCase):
-    """Test configuration of the application database"""
-
-    def setUp(self) -> None:
-        """Reset application settings to defaults"""
-
-        ApplicationSettings.reset_defaults()
-
-    @classmethod
-    def tearDownClass(cls) -> None:
-        """Reset application settings to defaults"""
-
-        ApplicationSettings.reset_defaults()
-
-    def test_db_in_memory(self) -> None:
-        """Test debug mode forces an in-memory database"""
-
-        ApplicationSettings.set(db_url='sqlite:///:memory:')
-        self.assertEqual('sqlite:///:memory:', DBConnection.url)
-
-    def test_db_matches_default_settings(self) -> None:
-        """Test debug mode forces an in-memory database"""
-
-        self.assertEqual(ApplicationSettings.get('db_url'), DBConnection.url)


### PR DESCRIPTION
This is an architectural improvement that has been sitting in the back of my mind for a while. 

I originally put the configuration of the application in the `ApplicationSettings` class because I thought it would simplify configuration during testing. The thought was "if the `ApplicationSettings` class automatically handles configuration every time the settings are changed, I'll have less to deal with during testing detup/teardown". Turns out it saved very little (nothing actually) and added more work because the configuration then needed to be tested as part of the `ApplicationSettings` and `Application` classes.