### PR TITLE
Remove Pitt specific content from email template

### DIFF
--- a/quota_notifier/data/template.html
+++ b/quota_notifier/data/template.html
@@ -1,13 +1,10 @@
 <p>
-  This is an automated notification concerning your storage quota on H2P.
+  This is an automated notification concerning your storage quota.
   One or more of your quotas has recently surpassed a usage threshold triggering an automated notification.
   Your storage usage is as follows:
 </p>
 <p>
   {usage_summary}
-</p>
-<p>
-  No immediate action is required on your part.
 </p>
 <p>
   Sincerely,


### PR DESCRIPTION
In order to keep the package generic, I've dropped Pitt specific content from the email template. User's (including the CRC) should customize this in production.