### PR TITLE
Fix bug where python -m doesn't work if package not installed

### DIFF
--- a/quota_notifier/__init__.py
+++ b/quota_notifier/__init__.py
@@ -30,9 +30,8 @@ a threshold before exceeding the threshold a second time.
 
 import importlib.metadata
 
-from .settings import ApplicationSettings as _settings
+try:
+    __version__ = importlib.metadata.version('asdf')
 
-__version__ = importlib.metadata.version(__package__)
-
-# Automatically configure default application settings
-_settings.reset_defaults()
+except importlib.metadata.PackageNotFoundError:
+    __version__ = '0.0.0'

--- a/quota_notifier/settings.py
+++ b/quota_notifier/settings.py
@@ -231,7 +231,7 @@ class ApplicationSettings:
     Use the ``configure_from_file`` method to load settings from a settings file.
     """
 
-    _parsed_settings: SettingsSchema = None
+    _parsed_settings: SettingsSchema = SettingsSchema()
 
     @classmethod
     def set_from_file(cls, path: Path) -> None:


### PR DESCRIPTION
The command `python -m quota_notifier` should work even if the package is not installed. Unfortunately this didn't work because package metadata couldn't be found.