### PR TITLE
Log error and continue on notification error

### DIFF
--- a/quota_notifier/notify.py
+++ b/quota_notifier/notify.py
@@ -285,4 +285,9 @@ class UserNotifier:
 
         logging.info('Scanning user quotas...')
         for user in users:
-            self.notify_user(user)
+            try:
+                self.notify_user(user)
+
+            except Exception as caught:
+                logging.getLogger('file_logger').error(f'Error notifying {user}', exc_info=caught)
+                logging.getLogger('console_logger').error(f'Error notifying {user} - {caught}')


### PR DESCRIPTION
Resolves #219

If an error occurs when notifying a specific user, the application now logs the error and continues on to the next user. Trackback information is included in the log file but not the console.