### PR TITLE
Reset application settings more broadly during unit testing

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -1,0 +1,17 @@
+"""Custom parent classes and utilities for testing."""
+
+from quota_notifier.settings import ApplicationSettings
+
+
+class CleanSettingsMixin:
+    """Mixin for resting application settings before and after every test"""
+
+    def setUp(self) -> None:
+        """Reset application settings"""
+
+        ApplicationSettings.reset_defaults()
+
+    def tearDown(self) -> None:
+        """Reset application settings"""
+
+        ApplicationSettings.reset_defaults()

--- a/tests/base.py
+++ b/tests/base.py
@@ -3,8 +3,8 @@
 from quota_notifier.settings import ApplicationSettings
 
 
-class CleanSettingsMixin:
-    """Mixin for resting application settings before and after every test"""
+class DefaultSetupTeardown:
+    """Defines setup/tear down steps for resting default settings before/after every test"""
 
     def setUp(self) -> None:
         """Reset application settings"""

--- a/tests/cli/test_application.py
+++ b/tests/cli/test_application.py
@@ -8,16 +8,11 @@ from unittest import TestCase
 from quota_notifier.cli import Application
 from quota_notifier.orm import DBConnection
 from quota_notifier.settings import ApplicationSettings
+from tests.base import DefaultSetupTeardown
 
 
-class ConsoleLogging(TestCase):
+class ConsoleLogging(DefaultSetupTeardown, TestCase):
     """Test the application verbosity is set to match commandline arguments"""
-
-    @classmethod
-    def tearDownClass(cls) -> None:
-        """Reset application settings to defaults"""
-
-        ApplicationSettings.reset_defaults()
 
     def test_logger_has_stream_handler(self) -> None:
         """Test the console logger has a single ``StreamHandler``"""
@@ -78,7 +73,7 @@ class ConsoleLogging(TestCase):
         self._assert_console_logging_level(logging.DEBUG)
 
 
-class FileLogging(TestCase):
+class FileLogging(DefaultSetupTeardown, TestCase):
     """Test the configuration for logging to file"""
 
     def test_logger_has_file_handler(self) -> None:
@@ -113,18 +108,8 @@ class FileLogging(TestCase):
             self.assertIn(handler, logging.getLogger().handlers)
 
 
-class DatabaseConfiguration(TestCase):
+class DatabaseConfiguration(DefaultSetupTeardown, TestCase):
     """Test configuration of the application database"""
-
-    def tearDown(self) -> None:
-        """Restore default application settings
-
-        These tests run the full application, including the configuration
-        of application settings. As a result, settings need to be reset after
-        each run.
-        """
-
-        ApplicationSettings.reset_defaults()
 
     def test_db_in_memory(self) -> None:
         """Test debug mode forces an in-memory database"""

--- a/tests/disk_utils/test_quotafactory.py
+++ b/tests/disk_utils/test_quotafactory.py
@@ -1,4 +1,5 @@
 """Tests for the ``QuotaFactory`` class"""
+
 from pathlib import Path
 from unittest import TestCase
 

--- a/tests/notify/test_emailtemplate.py
+++ b/tests/notify/test_emailtemplate.py
@@ -8,9 +8,10 @@ from quota_notifier.disk_utils import GenericQuota
 from quota_notifier.notify import EmailTemplate
 from quota_notifier.settings import ApplicationSettings
 from quota_notifier.shell import User
+from tests.base import DefaultSetupTeardown
 
 
-class TemplateFormatting(TestCase):
+class TemplateFormatting(DefaultSetupTeardown, TestCase):
     """Test the formatting of the email template with quota information
 
     These tests don't enforce the overall formatting of the template, but do
@@ -44,19 +45,15 @@ class TemplateFormatting(TestCase):
         self.assertIn(quota_text, self.template.message)
 
 
-class MessageSending(TestCase):
+class MessageSending(DefaultSetupTeardown, TestCase):
     """Tests for sending emails via an SMTP server"""
 
     def setUp(self) -> None:
         """Create a formatted email template"""
 
+        ApplicationSettings.reset_defaults()
         self.quota = GenericQuota('testquota', Path('/'), User('test_user'), size_used=10, size_limit=100)
         self.template = EmailTemplate([self.quota])
-
-    def tearDown(self) -> None:
-        """Reset any modified application settings"""
-
-        ApplicationSettings.reset_defaults()
 
     @patch('smtplib.SMTP')
     def test_fields_are_set(self, mock_smtp) -> None:
@@ -103,13 +100,8 @@ class MessageSending(TestCase):
         self.assertFalse(mock_smtp.mock_calls)
 
 
-class SendingByUsername(TestCase):
+class SendingByUsername(DefaultSetupTeardown, TestCase):
     """Test sending emails via username instead of address"""
-
-    def tearDown(self) -> None:
-        """Reset application settings to default values"""
-
-        ApplicationSettings.reset_defaults()
 
     @patch('smtplib.SMTP')
     def test_domain_matches_settings(self, mock_smtp) -> None:

--- a/tests/notify/test_usernotifier.py
+++ b/tests/notify/test_usernotifier.py
@@ -14,15 +14,11 @@ from quota_notifier.notify import UserNotifier
 from quota_notifier.orm import DBConnection, Notification
 from quota_notifier.settings import ApplicationSettings, FileSystemSchema
 from quota_notifier.shell import User
+from tests.base import DefaultSetupTeardown
 
 
-class GetUsers(TestCase):
+class GetUsers(DefaultSetupTeardown, TestCase):
     """Test the ``get_users`` method"""
-
-    def tearDown(self) -> None:
-        """Reset any modifications to application settings after each test"""
-
-        ApplicationSettings.reset_defaults()
 
     def test_empty_blacklists(self) -> None:
         """Test all users are returned for empty blacklists"""
@@ -61,11 +57,13 @@ class GetUsers(TestCase):
         self.assertNotIn(0, returned_gids)
 
 
-class GetUserQuotas(TestCase):
+class GetUserQuotas(DefaultSetupTeardown, TestCase):
     """Test the fetching of user quotas via the ``get_user_quotas`` method"""
 
     def setUp(self) -> None:
         """Create and register a temporary directory to generate quota objects for"""
+
+        ApplicationSettings.reset_defaults()
 
         # Register a temporary directory with the application
         self.temp_dir = TemporaryDirectory()
@@ -96,12 +94,13 @@ class GetUserQuotas(TestCase):
         self.assertEqual(self.test_user.group, quota.path.name)
 
 
-class GetLastThreshold(TestCase):
+class GetLastThreshold(DefaultSetupTeardown, TestCase):
     """Test fetching a quota's last notification threshold via the ``get_last_threshold`` method"""
 
     def setUp(self) -> None:
         """Run tests against a temporary database in memory"""
 
+        ApplicationSettings.reset_defaults()
         DBConnection.configure(url='sqlite:///:memory:')
 
     def test_missing_notification_history(self) -> None:
@@ -135,7 +134,7 @@ class GetLastThreshold(TestCase):
         self.assertEqual(test_threshold, threshold)
 
 
-class GetNextThreshold(TestCase):
+class GetNextThreshold(DefaultSetupTeardown, TestCase):
     """Test determination of the next notification threshold"""
 
     def setUp(self) -> None:
@@ -206,7 +205,7 @@ class GetNextThreshold(TestCase):
 
 
 @patch('quota_notifier.notify.SMTP')
-class NotificationHistory(TestCase):
+class NotificationHistory(DefaultSetupTeardown, TestCase):
     """Test the database updates after calling ``notify_user``"""
 
     def setUp(self) -> None:

--- a/tests/orm/test_dbconnection.py
+++ b/tests/orm/test_dbconnection.py
@@ -4,9 +4,10 @@ from tempfile import NamedTemporaryFile
 from unittest import TestCase
 
 from quota_notifier.orm import DBConnection
+from tests.base import DefaultSetupTeardown
 
 
-class DBConfiguration(TestCase):
+class DBConfiguration(DefaultSetupTeardown, TestCase):
     """Test configuration of the DB connection via the ``configure`` method"""
 
     def test_connection_is_reset(self) -> None:

--- a/tests/orm/test_notification.py
+++ b/tests/orm/test_notification.py
@@ -5,9 +5,11 @@ from unittest import TestCase
 from sqlalchemy import select
 
 from quota_notifier.orm import DBConnection, Notification
+from quota_notifier.settings import ApplicationSettings
+from tests.base import DefaultSetupTeardown
 
 
-class ThresholdValidation(TestCase):
+class ThresholdValidation(DefaultSetupTeardown, TestCase):
     """Test value validation for the ``threshold`` column"""
 
     def test_value_is_assigned(self) -> None:
@@ -34,7 +36,7 @@ class ThresholdValidation(TestCase):
             self.assertEqual(threshold, notification.threshold)
 
 
-class RequiredFields(TestCase):
+class RequiredFields(DefaultSetupTeardown, TestCase):
     """Test required fields are not nullable"""
 
     required_columns = (
@@ -51,12 +53,13 @@ class RequiredFields(TestCase):
             self.assertFalse(column.nullable, f'Column {column} should not be nullable')
 
 
-class UpdateOnConflict(TestCase):
+class UpdateOnConflict(DefaultSetupTeardown, TestCase):
     """Test records are updated on uniqueness conflict"""
 
     def setUp(self) -> None:
         """Set up an empty mock database"""
 
+        ApplicationSettings.reset_defaults()
         DBConnection.configure('sqlite:///:memory:')
 
     def test_records_updated(self) -> None:

--- a/tests/settings/test_applicationsettings.py
+++ b/tests/settings/test_applicationsettings.py
@@ -8,16 +8,11 @@ from unittest import TestCase
 from pydantic import ValidationError
 
 from quota_notifier.settings import ApplicationSettings
+from tests.base import DefaultSetupTeardown
 
 
-class Defaults(TestCase):
+class Defaults(DefaultSetupTeardown, TestCase):
     """Test default settings"""
-
-    @classmethod
-    def setUpClass(cls) -> None:
-        """Set application settings to default values"""
-
-        ApplicationSettings.reset_defaults()
 
     def test_blacklisted_root_user(self) -> None:
         """Test root is in blacklisted users"""
@@ -30,7 +25,7 @@ class Defaults(TestCase):
         self.assertEqual({0, }, ApplicationSettings.get('gid_blacklist'))
 
 
-class ResetDefaults(TestCase):
+class ResetDefaults(DefaultSetupTeardown, TestCase):
     """Test the overwriting of settings via the ``reset_defaults`` method"""
 
     def test_blacklist_is_reset(self) -> None:
@@ -41,7 +36,7 @@ class ResetDefaults(TestCase):
         self.assertEqual({0, }, ApplicationSettings.get('uid_blacklist'))
 
 
-class ConfigureFromFile(TestCase):
+class ConfigureFromFile(DefaultSetupTeardown, TestCase):
     """Test the modification of settings via the ``configure_from_file`` method"""
 
     def test_setting_are_overwritten(self) -> None:
@@ -71,7 +66,7 @@ class ConfigureFromFile(TestCase):
                 ApplicationSettings.set_from_file(path_obj)
 
 
-class Set(TestCase):
+class Set(DefaultSetupTeardown, TestCase):
     """Test application settings can be manipulated via the ``set`` method"""
 
     def test_setting_is_updated(self) -> None:

--- a/tests/settings/test_filesystemschema.py
+++ b/tests/settings/test_filesystemschema.py
@@ -8,9 +8,10 @@ from pydantic import ValidationError
 
 from quota_notifier.disk_utils import QuotaFactory
 from quota_notifier.settings import FileSystemSchema
+from tests.base import DefaultSetupTeardown
 
 
-class NameValidation(TestCase):
+class NameValidation(DefaultSetupTeardown, TestCase):
     """Test validation of the file system ``name`` field"""
 
     def test_blank_name_error(self) -> None:
@@ -30,7 +31,7 @@ class NameValidation(TestCase):
         self.assertEqual('abc', validated_name)
 
 
-class PathValidation(TestCase):
+class PathValidation(DefaultSetupTeardown, TestCase):
     """Test validation of the ``path`` field"""
 
     def test_existing_path_validates(self) -> None:
@@ -47,7 +48,7 @@ class PathValidation(TestCase):
             FileSystemSchema.validate_path(Path('/fake/path'))
 
 
-class TypeValidation(TestCase):
+class TypeValidation(DefaultSetupTeardown, TestCase):
     """Test validation of the ``type`` field"""
 
     @staticmethod
@@ -64,7 +65,7 @@ class TypeValidation(TestCase):
             FileSystemSchema(type='fake_type')
 
 
-class ThresholdValidation(TestCase):
+class ThresholdValidation(DefaultSetupTeardown, TestCase):
     """Test validation of the ``threshold`` field"""
 
     def test_intermediate_values_pass(self) -> None:

--- a/tests/settings/test_settingsschema.py
+++ b/tests/settings/test_settingsschema.py
@@ -5,9 +5,10 @@ from pathlib import Path
 from unittest import TestCase
 
 from quota_notifier.settings import FileSystemSchema, SettingsSchema
+from tests.base import DefaultSetupTeardown
 
 
-class BlacklistValidation(TestCase):
+class BlacklistValidation(DefaultSetupTeardown, TestCase):
     """Test validation for the ``uid_blacklist`` and ``gid_blacklist`` fields"""
 
     def test_error_on_id_range_len_1(self) -> None:
@@ -38,7 +39,7 @@ class BlacklistValidation(TestCase):
             SettingsSchema(gid_blacklist=['root', ])
 
 
-class FileSystemValidation(TestCase):
+class FileSystemValidation(DefaultSetupTeardown, TestCase):
     """Test validation for the ``file_systems`` field"""
 
     def test_error_on_duplicate_path(self) -> None:
@@ -70,7 +71,7 @@ class FileSystemValidation(TestCase):
         self.assertEqual(valid_input, returned_value)
 
 
-class DefaultDBUrl(TestCase):
+class DefaultDBUrl(DefaultSetupTeardown, TestCase):
     """Tests for the default database path"""
 
     def test_is_sqlite(self) -> None:


### PR DESCRIPTION
Resolves #224 by implementing a class with default setup/teardown logic for resetting application settings during tests.