### PR TITLE
Clean up error output when validating settings values

### DIFF
--- a/docs/source/overview/installation.rst
+++ b/docs/source/overview/installation.rst
@@ -44,7 +44,7 @@ The :doc:`file_systems` page provides an overview of supported file system types
        ],
        "email_from": "no-reply@domain.com",
        "email_domain": "@domain.com",
-       "email_admins": ["admin.user@domain.com"]
+       "admin_emails": ["admin.user@domain.com"]
    }
 
 Once the application has been configured, you can check the configuration file is valid by running:

--- a/quota_notifier/cli.py
+++ b/quota_notifier/cli.py
@@ -11,6 +11,7 @@ Module Contents
 
 import logging
 import logging.config
+import sys
 from argparse import ArgumentParser
 from pathlib import Path
 from smtplib import SMTP
@@ -116,7 +117,7 @@ class Application:
                     'level': 'CRITICAL',
                     'mailhost': ApplicationSettings.get('smtp_host'),
                     'fromaddr': ApplicationSettings.get('email_from'),
-                    'toaddrs': ApplicationSettings.get('email_admins'),
+                    'toaddrs': ApplicationSettings.get('admin_emails'),
                     'subject': 'Quota Notifier - Admin Notification'
                 }
             },
@@ -167,7 +168,13 @@ class Application:
         """
 
         # Configure application settings
-        cls._load_settings(force_debug=debug)
+        try:
+            cls._load_settings(force_debug=debug)
+
+        except Exception as e:
+            print(e)
+            sys.exit(0)
+
         if validate:
             return
 

--- a/quota_notifier/settings.py
+++ b/quota_notifier/settings.py
@@ -7,7 +7,6 @@ application settings in memory.
 Module Contents
 ---------------
 """
-
 import logging
 from pathlib import Path
 from tempfile import NamedTemporaryFile
@@ -180,7 +179,7 @@ class SettingsSchema(BaseSettings):
         description=('String to append to usernames when generating user email addresses. '
                      'The leading `@` is optional.'))
 
-    email_admins: List[str] = Field(
+    admin_emails: List[str] = Field(
         title='Administrator Emails',
         default=[],
         description='Admin users to contact when the application encounters a critical issue.'
@@ -237,16 +236,7 @@ class ApplicationSettings:
             path: Path to load settings from
         """
 
-        logging.debug(f'Looking for settings file: {path.resolve()}')
-
-        try:
-            cls._parsed_settings = SettingsSchema.parse_file(path)
-
-        except Exception:
-            logging.error('settings file is invalid')
-            raise
-
-        logging.info(f'Loaded settings from file: {path.resolve()}')
+        cls._parsed_settings = SettingsSchema.model_validate_json(path.read_text())
 
     @classmethod
     def set(cls, **kwargs) -> None:


### PR DESCRIPTION
Logging configuration requires knowing the application settings. This means settings validation occurs before logging is configured and errors returned by the `--validate` option are printed to stdout in a messy way. This PR cleans up the output.