### PR TITLE
Update filesystem interaction to align with crc-quota

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,6 @@ Run `notifier --help` for the full argument list.
 
 | Setting            | Default                               | Description                                                                                         |
 |--------------------|---------------------------------------|-----------------------------------------------------------------------------------------------------|
-| `ihome_quota_path` | `/ihome/crc/scripts/ihome_quota.json` | Path to ihome storage information.                                                                  |
 | `file_systems`     | `[]`                                  | List of file systems to examine. See [File System Settings](#file-system-settings).                 |
 | `uid_blacklist`    | `[0]`                                 | Do not notify users with these UID values.                                                          |
 | `gid_blacklist`    | `[0]`                                 | Do not notify groups with these GID values.                                                         |
@@ -108,12 +107,12 @@ Run `notifier --help` for the full argument list.
 
 Each entry in the `file_systems` list requires the following fields:
 
-| Setting      | Description                                               |
-|--------------|-----------------------------------------------------------|
-| `name`       | Human-readable name for the file system.                  |
-| `path`       | Absolute path to the mounted file system.                 |
-| `type`       | File system type. One of `ihome`, `generic`, or `beegfs`. |
-| `thresholds` | Usage percentages to issue notifications for.             |
+| Setting      | Description                                                       |
+|--------------|-------------------------------------------------------------------|
+| `name`       | Human-readable name for the file system.                          |
+| `path`       | Absolute path to the mounted file system.                         |
+| `type`       | File system type. One of `ihome`, `generic`, `beegfs`, or `vast`. |
+| `thresholds` | Usage percentages to issue notifications for.                     |
 
 Adding a new file system type also requires updating `QuotaType` in
 `quota_notifier.disk_utils.QuotaFactory`.
@@ -152,12 +151,18 @@ indicated with curly braces:
 Most file systems are supported by default, with dedicated support for the types below.
 
 **Generic** — Any file system where usage and available space can be determined with
-`df`. Generic file systems **must** be organized so that each subdirectory is named
-after a user group. For a file system mounted at `/mnt`, the directory for group
+`os.statvfs`. Generic file systems **must** be organized so that each subdirectory is
+named after a user group. For a file system mounted at `/mnt`, the directory for group
 `group1` must be `/mnt/group1`. Directories not named after a user group are ignored,
 and a directory does not have to exist for every group.
 
 **BeeGFS** — Quota information is read directly from the `beegfs-ctl` utility, so there
 are no requirements on how the file system is organized.
 
-**ihome** — Usage information is read from the JSON file at `ihome_quota_path`.
+**ihome** — Usage is determined with `os.statvfs` against the user's home directory.
+Since VAST reports the quota limit as the size of the underlying file system when no
+quota is configured, a user is skipped if their reported size is within 1% of the
+enclosing mount point's size.
+
+**vast** — Usage is determined the same way as **ihome**, but against a group directory
+on VAST-hosted storage (organized the same way as **generic** file systems).

--- a/docs/source/overview/configuration.rst
+++ b/docs/source/overview/configuration.rst
@@ -38,8 +38,6 @@ Core Settings
 +------------------+-----------------------------------------+---------------------------------------------------------+
 | Setting          | Default Value                           | Description                                             |
 +==================+=========================================+=========================================================+
-| ihome_quota_path | ``/ihome/crc/scripts/ihome_quota.json`` | Path to ihome storage information.                      |
-+------------------+-----------------------------------------+---------------------------------------------------------+
 | file_systems     | ``[]``                                  | List of file systems to examine. See the                |
 |                  |                                         | :ref:`fs-label` section for details                     |
 +------------------+-----------------------------------------+---------------------------------------------------------+
@@ -96,8 +94,8 @@ The following fields are required when defining which file systems to scan.
 +------------------------+---------------------------------------------------------------------------------------------+
 | path                   | Absolute path to the mounted file system.                                                   |
 +------------------------+---------------------------------------------------------------------------------------------+
-| type                   | Type of the file system. Options: ``ihome``, ``generic``, ``beegfs``. If modifying options, |
-|                        | update QuotaType in ``quota_notifier.disk_utils.QuotaFactory``.                             |
+| type                   | Type of the file system. Options: ``ihome``, ``generic``, ``beegfs``, ``vast``. If          |
+|                        | modifying options, update QuotaType in ``quota_notifier.disk_utils.QuotaFactory``.          |
 +------------------------+---------------------------------------------------------------------------------------------+
 | thresholds             | Usage percentages to issue notifications for.                                               |
 +------------------------+---------------------------------------------------------------------------------------------+

--- a/quota_notifier/disk_utils.py
+++ b/quota_notifier/disk_utils.py
@@ -1,8 +1,8 @@
 """Utilities for fetching disk quota information.
 
 Different quota objects (classes) are provided for different file system structures.
-The ``GenericQuota`` is generally applicable to any file system whose
-quota can be determined using the ``df`` commandline utility.
+The ``GenericQuota`` is generally applicable to any file system whose usage and quota
+can be determined via ``os.statvfs``.
 
 Quota classes may provide factory methods to facilitate creating instances
 based on simple user data. In all cases, these methods will return ``None``
@@ -17,16 +17,15 @@ Module Contents
 
 from __future__ import annotations
 
-import json
 import logging
 import math
+import os
 from abc import abstractmethod
 from copy import copy
 from enum import Enum
 from pathlib import Path
 from typing import Iterable, Optional
 
-from .settings import ApplicationSettings
 from .shell import ShellCmd, User
 
 
@@ -119,23 +118,19 @@ class GenericQuota(AbstractQuota):
 
         Returns:
             An instance of the parent class or None if the allocation does not exist
-
-        Raises:
-            RuntimeError: If something goes wrong communicating with the file system
         """
 
         logging.debug(f'fetching generic quota for {user.username} at {path}')
         if not path.exists():
-            logging.debug(f'Could not file path: {path}')
+            logging.debug(f'Could not find path: {path}')
             return None
 
-        df_command = ShellCmd(f"df {path}")
-        if df_command.err:
-            logging.error(df_command.err)
-            return None
+        stat = os.statvfs(path)
+        block_size = stat.f_frsize
+        size_limit = stat.f_blocks * block_size
+        size_used = (stat.f_blocks - stat.f_bavail) * block_size
 
-        result = df_command.out.splitlines()[1].split()
-        quota = cls(name, path, user, int(result[2]) * 1024, int(result[1]) * 1024)
+        quota = cls(name, path, user, size_used, size_limit)
         logging.debug(str(quota))
         return quota
 
@@ -225,30 +220,35 @@ class BeeGFSQuota(AbstractQuota):
             cls._cached_quotas[path][int(gid)] = cls(name, path, None, int(used), int(avail))
 
 
-class IhomeQuota(AbstractQuota):
-    """Disk storage quota for the ihome file system"""
+class VastBackedQuota(AbstractQuota):
+    """Base class for quotas hosted on VAST file systems
 
-    _parsed_quota_data = None
+    VAST reports the quota limit as the size of the underlying mounted file
+    system when a directory has no quota configured. To detect whether a
+    quota is actually set, the reported size of the directory is compared
+    against the reported size of its enclosing mount point. Sizes within 1%
+    of each other are treated as "no quota configured".
+    """
 
-    @classmethod
-    def _get_quota_data(cls) -> dict:
-        """Parse and cache Ihome quota data
+    @staticmethod
+    def _find_mount_point(path: Path) -> Path:
+        """Return the mount point a given path is stored under
+
+        Args:
+            path: The file path to find the mount point for
 
         Returns:
-            Quota information as a dictionary
+            The nearest ancestor of ``path`` (possibly ``path`` itself) that is a mount point
         """
 
-        # Get the information from Isilon
-        if cls._parsed_quota_data is None:
-            ihome_data_path = ApplicationSettings.get('ihome_quota_path')
-            logging.debug(f'Parsing {ihome_data_path}')
-            with ihome_data_path.open('r') as infile:
-                cls._parsed_quota_data = json.load(infile)
+        path = path.resolve()
+        while not path.is_mount() and path.parent != path:
+            path = path.parent
 
-        return cls._parsed_quota_data
+        return path
 
     @classmethod
-    def get_quota(cls, name: str, path: Path, user: User) -> Optional[IhomeQuota]:
+    def get_quota(cls, name: str, path: Path, user: User) -> Optional[VastBackedQuota]:
         """Return a quota object for a given user and file path
 
         Args:
@@ -257,19 +257,37 @@ class IhomeQuota(AbstractQuota):
             user: User that the quota is tied to
 
         Returns:
-            An instance of the parent class or None if the allocation does not exist
+            An instance of the parent class or None if no quota is configured for the path
         """
 
-        logging.debug(f'fetching Ihome quota for {user.username} at {path}')
+        logging.debug(f'fetching {name} quota for {user.username} at {path}')
+        if not path.exists():
+            logging.debug(f'Could not find path: {path}')
+            return None
 
-        quota_data = cls._get_quota_data()
-        persona = f"UID:{user.uid}"
-        for item in quota_data["quotas"]:
-            if item["persona"] is not None:
-                if item["persona"]["id"] == persona:
-                    quota = cls(name, path, user, item["usage"]["logical"], item["thresholds"]["hard"])
-                    logging.debug(str(quota))
-                    return quota
+        stat = os.statvfs(path)
+        block_size = stat.f_frsize
+        size_limit = stat.f_blocks * block_size
+        size_used = (stat.f_blocks - stat.f_bavail) * block_size
+
+        mount_stat = os.statvfs(cls._find_mount_point(path))
+        mount_size = mount_stat.f_blocks * mount_stat.f_frsize
+
+        if mount_size and 0.99 <= (size_limit / mount_size) <= 1.01:
+            logging.debug(f'No quota configured for {user.username} at {path}')
+            return None
+
+        quota = cls(name, path, user, size_used, size_limit)
+        logging.debug(str(quota))
+        return quota
+
+
+class IhomeQuota(VastBackedQuota):
+    """Disk storage quota for the ihome file system hosted on VAST"""
+
+
+class VastQuota(VastBackedQuota):
+    """Disk storage quota for group/project storage hosted on VAST"""
 
 
 class QuotaFactory:
@@ -283,6 +301,7 @@ class QuotaFactory:
         generic = GenericQuota
         beegfs = BeeGFSQuota
         ihome = IhomeQuota
+        vast = VastQuota
 
     def __new__(cls, quota_type: str, name: str, path: Path, user: User, **kwargs) -> AbstractQuota:
         """Create a new quota instance

--- a/quota_notifier/notify.py
+++ b/quota_notifier/notify.py
@@ -146,9 +146,14 @@ class UserNotifier:
 
         quota_list = []
         for file_sys in ApplicationSettings.get('file_systems'):
-            user_path = file_sys.path
-            if file_sys.type == 'generic':
-                user_path /= user.group
+            if file_sys.type == 'ihome':
+                user_path = user.home_dir
+
+            elif file_sys.type in ('generic', 'vast'):
+                user_path = file_sys.path / user.group
+
+            else:
+                user_path = file_sys.path
 
             quota = QuotaFactory(quota_type=file_sys.type, name=file_sys.name, path=user_path, user=user)
             if quota:

--- a/quota_notifier/settings.py
+++ b/quota_notifier/settings.py
@@ -34,7 +34,7 @@ class FileSystemSchema(BaseSettings):
 
     # If modifying options for this setting, also update
     # quota_notifier.disk_utils.QuotaFactory.QuotaType
-    type: Literal['ihome', 'generic', 'beegfs'] = Field(
+    type: Literal['ihome', 'generic', 'beegfs', 'vast'] = Field(
         ...,
         title='System Type',
         description='Type of the file system')
@@ -107,11 +107,6 @@ class SettingsSchema(BaseSettings):
     """Defines the schema and default values for top level application settings"""
 
     # General application settings
-    ihome_quota_path: Path = Field(
-        title='Ihome Quota Path',
-        default=Path('/ihome/crc/scripts/ihome_quota.json'),
-        description='Path to ihome storage information.')
-
     file_systems: List[FileSystemSchema] = Field(
         title='Monitored File Systems',
         default=list(),

--- a/quota_notifier/shell.py
+++ b/quota_notifier/shell.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import grp
 import logging
 import pwd
+from pathlib import Path
 from shlex import split
 from subprocess import PIPE, Popen
 from typing import Optional, Iterator
@@ -92,6 +93,12 @@ class User:
         """Fetch and return the users group id"""
 
         return pwd.getpwnam(self._username).pw_gid
+
+    @property
+    def home_dir(self) -> Path:
+        """Fetch and return the users home directory"""
+
+        return Path(pwd.getpwnam(self._username).pw_dir)
 
     def __eq__(self, other):
         """Return true if both user objects have the same username"""

--- a/tests/shell/test_user.py
+++ b/tests/shell/test_user.py
@@ -1,6 +1,7 @@
 """Tests for the ``User`` class"""
 
 import pwd
+from pathlib import Path
 from unittest import TestCase
 
 from quota_notifier.shell import User
@@ -17,6 +18,12 @@ class UserInfo(TestCase):
         self.assertEqual(user.uid, 0)
         self.assertEqual(user.group, 'root')
         self.assertEqual(user.gid, 0)
+
+    def test_home_dir(self) -> None:
+        """Test the home directory matches the value reported by ``pwd``"""
+
+        user = User('root')
+        self.assertEqual(Path(pwd.getpwnam('root').pw_dir), user.home_dir)
 
 
 class IterAllUsers(TestCase):


### PR DESCRIPTION
We recently decided that this application's filesystem interfacing logic should mirror the mechanism already used by crc-quota in the wrappers repo.

I believe I've accomplished this with the following changes: 

- `GenericQuota` now reads usage/limit via `os.statvfs` instead of shelling out to `df`                                                                     
- `IhomeQuota` no longer parses the Isilon JSON dump (`ihome_quota_path` setting removed), it and a new VastQuota type both derive from a new `VastBackedQuota` base class that uses `os.statvfs` against the path and its enclosing mount point, treating a match within 1% as "no quota configured" (VAST reports the raw filesystem size when no quota is set)                                                                                         
- Added `User.home_dir` so ihome lookups resolve the user's actual home directory instead of a path built from `file_sys.path`                            
- `notify.py` branches on ihome / generic+vast / other to build the right per-user path                                                                 

I would still like to perform some additional sanity check testing out on the cluster before merging this in.

Also, I didn't remove the functionality around polling the BGFS, but we technically don't need that anymore.
